### PR TITLE
Fix lint errors in pages

### DIFF
--- a/src/pages/Approvals.tsx
+++ b/src/pages/Approvals.tsx
@@ -148,14 +148,24 @@ export default function Approvals() {
               placeholder="Search vendor, subscription, request by…"
             />
 
-            <select className="cs-select" style={{ width: 180 }} value={status} onChange={(e) => setStatus(e.target.value as any)}>
+            <select
+              className="cs-select"
+              style={{ width: 180 }}
+              value={status}
+              onChange={(e) => setStatus(e.target.value as ApprovalStatus | "All")}
+            >
               <option value="All">All status</option>
               <option value="Pending">Pending</option>
               <option value="Approved">Approved</option>
               <option value="Rejected">Rejected</option>
             </select>
 
-            <select className="cs-select" style={{ width: 160 }} value={risk} onChange={(e) => setRisk(e.target.value as any)}>
+            <select
+              className="cs-select"
+              style={{ width: 160 }}
+              value={risk}
+              onChange={(e) => setRisk(e.target.value as Risk | "All")}
+            >
               <option value="All">All risk</option>
               <option value="Low">Low</option>
               <option value="Medium">Medium</option>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -38,8 +38,8 @@ export default function Dashboard() {
       if (!Array.isArray(arr)) throw new Error("Unexpected response shape")
 
       setRows(arr as TenantRow[])
-    } catch (e: any) {
-      setError(e?.message || "Failed to fetch")
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to fetch")
     } finally {
       setLoading(false)
     }
@@ -47,7 +47,6 @@ export default function Dashboard() {
 
   useEffect(() => {
     load()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const metrics = useMemo(() => {

--- a/src/pages/Renewals.tsx
+++ b/src/pages/Renewals.tsx
@@ -96,28 +96,31 @@ export default function Renewals() {
   useEffect(() => {
     let active = true
 
-    setLoading(true)
-    setError(null)
+    const load = async () => {
+      if (!active) return
 
-    fetchSheetData<RenewalRow[]>("Renewals")
-      .then((data) => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const data = await fetchSheetData<RenewalRow[]>("Renewals")
         if (!active || !Array.isArray(data)) return
 
-        const normalized = data.map(toUiRow)
-        setRows(normalized)
-        setLoading(false)
-      })
-      .catch((err) => {
+        setRows(data.map(toUiRow))
+      } catch (err) {
         console.error("Failed to load renewals", err)
         if (!active) return
+
         setRows([])
         setError("Failed to load renewals. Please try again.")
-        setLoading(false)
-      })
-      .finally(() => {
-        if (!active) return
-        setLoading(false)
-      })
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void load()
 
     return () => {
       active = false
@@ -188,7 +191,12 @@ export default function Renewals() {
               placeholder="Search vendor, subscription, owner…"
             />
 
-            <select style={select} value={status} onChange={(e) => setStatus(e.target.value as any)} title="Status">
+            <select
+              style={select}
+              value={status}
+              onChange={(e) => setStatus(e.target.value as RenewalStatus | "All")}
+              title="Status"
+            >
               <option value="All">All statuses</option>
               <option value="Due">Due</option>
               <option value="In review">In review</option>
@@ -196,7 +204,12 @@ export default function Renewals() {
               <option value="Rejected">Rejected</option>
             </select>
 
-            <select style={select} value={risk} onChange={(e) => setRisk(e.target.value as any)} title="Risk">
+            <select
+              style={select}
+              value={risk}
+              onChange={(e) => setRisk(e.target.value as "All" | "Low" | "Medium" | "High")}
+              title="Risk"
+            >
               <option value="All">All risk</option>
               <option value="Low">Low</option>
               <option value="Medium">Medium</option>
@@ -467,7 +480,6 @@ const tr: React.CSSProperties = {
   cursor: "pointer",
   transition: "background 160ms ease, transform 160ms ease",
 }
-;(tr as any)[":hover"] = undefined // (keeps TS quiet if you accidentally paste into a CSS-in-JS lib)
 
 const td: React.CSSProperties = {
   padding: "12px 14px",

--- a/src/pages/admin/VendorNew.tsx
+++ b/src/pages/admin/VendorNew.tsx
@@ -13,6 +13,7 @@ const SHEET_URL =
   "https://script.google.com/macros/s/AKfycbwxTAPJITLdR3AUQoseEs-TsUefbWfuPPmt2rrqsmgDBGXSfAL3xDeUG10VLKUrGhDb0w/exec"
 
 type Step = 1 | 2 | 3 | 4
+type CreateResponse = { ok?: boolean; error?: string }
 
 export default function VendorNew() {
   const [step, setStep] = useState<Step>(1)
@@ -149,7 +150,7 @@ export default function VendorNew() {
       })
 
       // Read body ONCE
-      const json: any = await res.json().catch(() => null)
+      const json = (await res.json().catch(() => null)) as CreateResponse | null
 
       if (!res.ok) {
         throw new Error(json?.error || `HTTP ${res.status}`)
@@ -167,8 +168,9 @@ export default function VendorNew() {
       setLegalName("")
       setAdminName("")
       setAdminEmail("")
-    } catch (e: any) {
-      setError(`Create failed: ${e?.message || "Failed to fetch"}`)
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Failed to fetch"
+      setError(`Create failed: ${message}`)
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- update dashboard and admin vendor creation error handling to use typed errors
- replace `any` casts on approvals and renewals filters with explicit union types
- refactor renewals data loading to satisfy hook linting rules and keep cleanup safe

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954fd4925c88328af54493bd0b0a345)