### PR TITLE
Connect subscriptions pages to Apps Script data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import Approvals from "./pages/Approvals"
 // Real pages
 import Renewals from "./pages/Renewals"
 import RenewalDetail from "./pages/RenewalDetail"
+import Subscriptions from "./pages/Subscriptions"
+import SubscriptionDetail from "./pages/SubscriptionDetail"
 
 // Existing admin pages
 import Vendors from "./pages/admin/Vendors"
@@ -68,19 +70,8 @@ export default function App() {
         />
 
         {/* Subscriptions */}
-        <Route
-          path="/subscriptions"
-          element={
-            <PlaceholderPage
-              title="Subscriptions List"
-              subtitle="Plans, seats, renewals, and actions"
-            />
-          }
-        />
-        <Route
-          path="/subscriptions/detail"
-          element={<PlaceholderPage title="Subscription Detail" subtitle="Reclaim, edit, audit trail" />}
-        />
+        <Route path="/subscriptions" element={<Subscriptions />} />
+        <Route path="/subscriptions/detail" element={<SubscriptionDetail />} />
 
         {/* Users / identity */}
         <Route path="/users" element={<PlaceholderPage title="Users List" />} />

--- a/src/data/subscriptions.ts
+++ b/src/data/subscriptions.ts
@@ -1,0 +1,78 @@
+// src/data/subscriptions.ts
+import { fetchSheetData } from "./api"
+
+export const SUBSCRIPTIONS_TAB = "Subscriptions"
+
+export interface RawSubscriptionRow {
+  subscription_id?: string
+  entitlement_id?: string
+  id?: string
+  vendor_id?: string
+  vendor_name?: string
+  tenant_id?: string
+  subscription_status?: string
+  status?: string
+  subscription_name?: string
+  name?: string
+  start_date?: string
+  end_date?: string
+  renewed_price?: number | string
+  previous_price?: number | string
+  cost?: number | string
+  amount?: number | string
+  currency?: string
+}
+
+export interface SubscriptionRecord {
+  id: string
+  vendor: string
+  tenantId: string
+  name: string
+  status: string
+  startDate?: string
+  endDate?: string
+  amount?: number
+  currency?: string
+  raw: RawSubscriptionRow
+}
+
+function parseAmount(row: RawSubscriptionRow): number | undefined {
+  const candidates = [row.renewed_price, row.previous_price, row.cost, row.amount]
+
+  for (const candidate of candidates) {
+    const num = typeof candidate === "string" ? Number(candidate) : candidate
+    if (Number.isFinite(num)) {
+      return Number(num)
+    }
+  }
+
+  return undefined
+}
+
+function coalesceId(row: RawSubscriptionRow, fallback: string): string {
+  return row.subscription_id || row.entitlement_id || row.id || fallback
+}
+
+export function mapSubscriptionRow(
+  row: RawSubscriptionRow,
+  index = 0,
+): SubscriptionRecord {
+  return {
+    id: coalesceId(row, `unknown-${index + 1}`),
+    vendor: row.vendor_id || row.vendor_name || "Unknown vendor",
+    tenantId: row.tenant_id || "—",
+    name: row.subscription_name || row.name || row.vendor_name || "—",
+    status: row.subscription_status || row.status || "Unknown",
+    startDate: row.start_date || "",
+    endDate: row.end_date || "",
+    amount: parseAmount(row),
+    currency: row.currency || "USD",
+    raw: row,
+  }
+}
+
+export async function getSubscriptions(): Promise<SubscriptionRecord[]> {
+  const rows = await fetchSheetData<RawSubscriptionRow[]>(SUBSCRIPTIONS_TAB)
+  if (!Array.isArray(rows)) return []
+  return rows.map((row, idx) => mapSubscriptionRow(row, idx))
+}

--- a/src/pages/Renewals.tsx
+++ b/src/pages/Renewals.tsx
@@ -1,6 +1,6 @@
 // src/pages/Renewals.tsx
 import { useEffect, useMemo, useState } from "react"
-import { useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import { fetchSheetData } from "../data/api"
 import AppShell from "../layout/AppShell"
 
@@ -86,12 +86,23 @@ function fmtMoney(n: number) {
 
 export default function Renewals() {
   const nav = useNavigate()
-  const [q, setQ] = useState("")
+  const location = useLocation()
+  const initialQuery = useMemo(() => {
+    const stateSearch = (location.state as { search?: string } | undefined)?.search || ""
+    const params = new URLSearchParams(location.search)
+    return params.get("search") || stateSearch || ""
+  }, [location.search, location.state])
+
+  const [q, setQ] = useState(initialQuery)
   const [status, setStatus] = useState<"All" | RenewalStatus>("All")
   const [risk, setRisk] = useState<"All" | "Low" | "Medium" | "High">("All")
   const [rows, setRows] = useState<UiRenewalRow[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setQ(initialQuery)
+  }, [initialQuery])
 
   useEffect(() => {
     let active = true

--- a/src/pages/SubscriptionDetail.tsx
+++ b/src/pages/SubscriptionDetail.tsx
@@ -1,36 +1,261 @@
 // src/pages/SubscriptionDetail.tsx
+import { useEffect, useMemo, useState } from "react"
+import { useNavigate, useSearchParams } from "react-router-dom"
+import { getSubscriptions } from "../data/subscriptions"
+import type { SubscriptionRecord } from "../data/subscriptions"
 import AppShell from "../layout/AppShell"
 
+function fmtMoney(amount?: number, currency = "USD") {
+  if (typeof amount !== "number" || Number.isNaN(amount)) return "—"
+
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount)
+  } catch {
+    return `${currency} ${Math.round(amount).toLocaleString()}`
+  }
+}
+
 export default function SubscriptionDetail() {
+  const [params] = useSearchParams()
+  const nav = useNavigate()
+  const [rows, setRows] = useState<SubscriptionRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const id = params.get("id")?.trim() || ""
+
+  useEffect(() => {
+    let active = true
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const data = await getSubscriptions()
+        if (!active) return
+        setRows(data)
+      } catch (err) {
+        console.error("Failed to load subscriptions", err)
+        if (!active) return
+        setError("Failed to load subscription. Please try again.")
+        setRows([])
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void load()
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const match = useMemo(() => {
+    if (!id) return null
+    const needle = id.toLowerCase()
+
+    return (
+      rows.find((r) =>
+        [r.id, r.raw.entitlement_id, r.raw.id]
+          .filter(Boolean)
+          .some((candidate) => candidate?.toLowerCase() === needle),
+      ) || null
+    )
+  }, [id, rows])
+
+  const primaryVendorOrName = match?.vendor || match?.name || id
+
+  const actions = (
+    <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+      <button style={primaryBtn}>Reclaim Seats</button>
+      <button
+        style={ghostBtn}
+        onClick={() =>
+          nav(`/renewals?search=${encodeURIComponent(primaryVendorOrName)}`, {
+            state: { search: primaryVendorOrName },
+          })
+        }
+      >
+        View Renewals
+      </button>
+    </div>
+  )
+
   return (
-    <AppShell
-      title="Subscription Detail"
-      subtitle="Reclaim, edit, and audit trail"
-    >
-      <div style={card}>
-        <h3 style={h3}>Subscription Detail</h3>
-        <p style={muted}>
-          Detailed view for a single subscription (demo stub)
-        </p>
+    <AppShell title="Subscription Detail" subtitle="Reclaim, edit, and audit trail" actions={actions}>
+      <div style={stack}>
+        <div style={card}>
+          <div style={cardHead}>
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 16 }}>{match?.name || "Subscription"}</div>
+              <div style={muted}>ID: {match?.id || id || "(missing)"}</div>
+            </div>
+            <Badge tone={match?.status.toLowerCase().includes("active") ? "ok" : "info"}>
+              {match?.status || "Unknown"}
+            </Badge>
+          </div>
+
+          <div style={detailGrid}>
+            <DetailField label="Vendor" value={match?.vendor || "-"} />
+            <DetailField label="Tenant" value={match?.tenantId || "-"} />
+            <DetailField label="Start date" value={match?.startDate || "-"} />
+            <DetailField label="End date" value={match?.endDate || "-"} />
+            <DetailField label="Amount" value={fmtMoney(match?.amount, match?.currency)} />
+            <DetailField label="Currency" value={match?.currency || "-"} />
+            <DetailField label="Subscription ID" value={match?.id || "-"} mono />
+            <DetailField label="Entitlement ID" value={match?.raw.entitlement_id || "-"} mono />
+            <DetailField label="Raw status" value={match?.raw.status || "-"} />
+          </div>
+
+          {loading && <div style={muted}>Loading subscription…</div>}
+          {!loading && error && <div style={errorText}>{error}</div>}
+          {!loading && !error && !match && id && (
+            <div style={errorText}>Subscription not found for ID: {id}</div>
+          )}
+          {!id && <div style={errorText}>Missing subscription id.</div>}
+        </div>
       </div>
     </AppShell>
   )
 }
 
-/* styles */
+function DetailField({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div style={detailField}>
+      <div style={detailLabel}>{label}</div>
+      <div style={{ ...detailValue, ...(mono ? monoStyle : {}) }}>{value || "-"}</div>
+    </div>
+  )
+}
+
+function Badge({ children, tone }: { children: React.ReactNode; tone: "ok" | "warn" | "danger" | "info" }) {
+  const bg =
+    tone === "ok"
+      ? "rgba(52,199,89,0.12)"
+      : tone === "warn"
+        ? "rgba(255,159,10,0.14)"
+        : tone === "danger"
+          ? "rgba(255,59,48,0.12)"
+          : "rgba(10,132,255,0.12)"
+
+  const border =
+    tone === "ok"
+      ? "rgba(52,199,89,0.25)"
+      : tone === "warn"
+        ? "rgba(255,159,10,0.28)"
+        : tone === "danger"
+          ? "rgba(255,59,48,0.25)"
+          : "rgba(10,132,255,0.22)"
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "6px 10px",
+        borderRadius: 999,
+        background: bg,
+        border: `1px solid ${border}`,
+        fontSize: 12,
+        fontWeight: 700,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+/* Styles */
+const stack: React.CSSProperties = { display: "grid", gap: 14 }
+
 const card: React.CSSProperties = {
   background: "#fff",
   borderRadius: 16,
-  padding: 20,
   border: "1px solid rgba(15,23,42,0.08)",
+  overflow: "hidden",
 }
 
-const h3: React.CSSProperties = {
-  margin: 0,
-  fontSize: 18,
+const cardHead: React.CSSProperties = {
+  padding: 14,
+  borderBottom: "1px solid rgba(15,23,42,0.08)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 12,
+  flexWrap: "wrap",
 }
 
 const muted: React.CSSProperties = {
   color: "rgba(15,23,42,0.6)",
+  fontSize: 13,
+}
+
+const detailGrid: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+  gap: 12,
+  padding: 14,
+}
+
+const detailField: React.CSSProperties = {
+  background: "rgba(15,23,42,0.02)",
+  borderRadius: 12,
+  padding: 12,
+  border: "1px solid rgba(15,23,42,0.06)",
+}
+
+const detailLabel: React.CSSProperties = {
+  fontSize: 12,
+  color: "rgba(15,23,42,0.6)",
+  fontWeight: 700,
+}
+
+const detailValue: React.CSSProperties = {
   marginTop: 6,
+  fontSize: 15,
+  fontWeight: 800,
+}
+
+const monoStyle: React.CSSProperties = {
+  fontFamily:
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+  fontSize: 13,
+}
+
+const errorText: React.CSSProperties = {
+  color: "rgba(255,59,48,0.9)",
+  padding: "0 14px 14px",
+  fontWeight: 700,
+}
+
+const ghostBtn: React.CSSProperties = {
+  height: 42,
+  padding: "0 14px",
+  borderRadius: 12,
+  border: "1px solid rgba(15,23,42,0.12)",
+  background: "#fff",
+  fontWeight: 700,
+}
+
+const primaryBtn: React.CSSProperties = {
+  height: 42,
+  padding: "0 14px",
+  borderRadius: 12,
+  border: "1px solid rgba(10,132,255,0.25)",
+  background: "rgba(10,132,255,0.12)",
+  fontWeight: 800,
 }

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -1,49 +1,470 @@
 // src/pages/Subscriptions.tsx
+import { useEffect, useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { getSubscriptions } from "../data/subscriptions"
+import type { SubscriptionRecord } from "../data/subscriptions"
 import AppShell from "../layout/AppShell"
 
+function fmtMoney(amount?: number, currency = "USD") {
+  if (typeof amount !== "number" || Number.isNaN(amount)) return "—"
+
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount)
+  } catch {
+    return `${currency} ${Math.round(amount).toLocaleString()}`
+  }
+}
+
+function isDueSoon(endDate?: string) {
+  if (!endDate) return false
+  const date = new Date(endDate)
+  if (Number.isNaN(date.getTime())) return false
+
+  const now = new Date()
+  const diff = date.getTime() - now.getTime()
+  const days = diff / (1000 * 60 * 60 * 24)
+  return days >= 0 && days <= 60
+}
+
 export default function Subscriptions() {
+  const nav = useNavigate()
+  const [rows, setRows] = useState<SubscriptionRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState("")
+  const [statusFilter, setStatusFilter] = useState("All")
+  const [tenantFilter, setTenantFilter] = useState("All")
+
+  useEffect(() => {
+    let active = true
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const data = await getSubscriptions()
+        if (!active) return
+        setRows(data)
+      } catch (err) {
+        console.error("Failed to load subscriptions", err)
+        if (!active) return
+        setError("Failed to load subscriptions. Please try again.")
+        setRows([])
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void load()
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const statusOptions = useMemo(() => {
+    const unique = new Set<string>()
+    rows.forEach((r) => {
+      const val = r.status?.trim()
+      if (val) unique.add(val)
+    })
+    return Array.from(unique)
+  }, [rows])
+
+  const tenantOptions = useMemo(() => {
+    const unique = new Set<string>()
+    rows.forEach((r) => {
+      const val = r.tenantId?.trim()
+      if (val) unique.add(val)
+    })
+    unique.delete("—")
+    return Array.from(unique)
+  }, [rows])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+
+    return rows.filter((r) => {
+      const matchesQuery =
+        !q ||
+        r.vendor.toLowerCase().includes(q) ||
+        r.name.toLowerCase().includes(q) ||
+        r.id.toLowerCase().includes(q)
+
+      const matchesStatus =
+        statusFilter === "All" || r.status.toLowerCase() === statusFilter.toLowerCase()
+
+      const matchesTenant = tenantFilter === "All" || r.tenantId === tenantFilter
+
+      return matchesQuery && matchesStatus && matchesTenant
+    })
+  }, [rows, query, statusFilter, tenantFilter])
+
+  const totalSubscriptions = filtered.length
+  const activeCount = filtered.filter((r) => r.status.toLowerCase().includes("active")).length
+  const dueSoonCount = filtered.filter((r) => isDueSoon(r.endDate)).length
+
   return (
     <AppShell
       title="Subscriptions"
       subtitle="Plans, seats, renewals, and actions"
+      actions={
+        <button style={primaryBtn} onClick={() => nav("/renewals")}>
+          View Renewals
+        </button>
+      }
     >
-      <div style={card}>
-        <h3 style={h3}>Subscriptions List</h3>
-        <p style={muted}>
-          This will show all active subscriptions with reclaim and renewal
-          actions.
-        </p>
+      <div style={stack}>
+        {/* KPI strip */}
+        <div style={kpiGrid}>
+          <Kpi title="Total subscriptions" value={totalSubscriptions.toString()} />
+          <Kpi title="Active" value={activeCount.toString()} />
+          <Kpi title="Due for renewal" value={dueSoonCount.toString()} />
+        </div>
 
-        <div style={emptyState}>
-          No subscriptions yet (demo stub)
+        {/* Action bar */}
+        <div style={bar}>
+          <div style={barLeft}>
+            <input
+              style={search}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search vendor, subscription, or ID"
+            />
+
+            <select
+              style={select}
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+            >
+              <option value="All">All statuses</option>
+              {statusOptions.map((s) => (
+                <option key={s} value={s}>
+                  {s || "(empty)"}
+                </option>
+              ))}
+            </select>
+
+            {tenantOptions.length > 0 && (
+              <select
+                style={select}
+                value={tenantFilter}
+                onChange={(e) => setTenantFilter(e.target.value)}
+              >
+                <option value="All">All tenants</option>
+                {tenantOptions.map((t) => (
+                  <option key={t} value={t}>
+                    {t || "(empty)"}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div style={barRight}>
+            <button
+              style={ghostBtn}
+              onClick={() => {
+                setQuery("")
+                setStatusFilter("All")
+                setTenantFilter("All")
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div style={card}>
+          <div style={cardHead}>
+            <div style={{ fontWeight: 700 }}>Subscriptions list</div>
+            <div style={muted}>Click a row to open detail.</div>
+          </div>
+
+          <div style={{ overflowX: "auto" }}>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Subscription ID</th>
+                  <th style={th}>Vendor</th>
+                  <th style={th}>Name</th>
+                  <th style={th}>Tenant</th>
+                  <th style={th}>Status</th>
+                  <th style={th}>Start</th>
+                  <th style={th}>End</th>
+                  <th style={thRight}>Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading && (
+                  <tr>
+                    <td style={tdEmpty} colSpan={8}>
+                      Loading subscriptions…
+                    </td>
+                  </tr>
+                )}
+
+                {!loading && error && (
+                  <tr>
+                    <td style={tdEmpty} colSpan={8}>
+                      {error}
+                    </td>
+                  </tr>
+                )}
+
+                {!loading && !error &&
+                  filtered.map((r) => (
+                    <tr
+                      key={r.id}
+                      style={tr}
+                      onClick={() => nav(`/subscriptions/detail?id=${encodeURIComponent(r.id)}`)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ")
+                          nav(`/subscriptions/detail?id=${encodeURIComponent(r.id)}`)
+                      }}
+                      role="button"
+                      tabIndex={0}
+                      title="Open subscription detail"
+                    >
+                      <td style={tdMono}>{r.id}</td>
+                      <td style={tdStrong}>{r.vendor}</td>
+                      <td style={td}>{r.name}</td>
+                      <td style={td}>{r.tenantId}</td>
+                      <td style={td}>
+                        <Badge tone={r.status.toLowerCase().includes("active") ? "ok" : "info"}>
+                          {r.status}
+                        </Badge>
+                      </td>
+                      <td style={tdMono}>{r.startDate || "-"}</td>
+                      <td style={tdMono}>{r.endDate || "-"}</td>
+                      <td style={tdRight}>{fmtMoney(r.amount, r.currency)}</td>
+                    </tr>
+                  ))}
+
+                {!loading && !error && filtered.length === 0 && (
+                  <tr>
+                    <td style={tdEmpty} colSpan={8}>
+                      No subscriptions found.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </AppShell>
   )
 }
 
-/* styles */
-const card: React.CSSProperties = {
+function Kpi({ title, value }: { title: string; value: string }) {
+  return (
+    <div style={kpi}>
+      <div style={kpiTitle}>{title}</div>
+      <div style={kpiValue}>{value}</div>
+    </div>
+  )
+}
+
+function Badge({ children, tone }: { children: React.ReactNode; tone: "ok" | "warn" | "danger" | "info" }) {
+  const bg =
+    tone === "ok"
+      ? "rgba(52,199,89,0.12)"
+      : tone === "warn"
+        ? "rgba(255,159,10,0.14)"
+        : tone === "danger"
+          ? "rgba(255,59,48,0.12)"
+          : "rgba(10,132,255,0.12)"
+
+  const border =
+    tone === "ok"
+      ? "rgba(52,199,89,0.25)"
+      : tone === "warn"
+        ? "rgba(255,159,10,0.28)"
+        : tone === "danger"
+          ? "rgba(255,59,48,0.25)"
+          : "rgba(10,132,255,0.22)"
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "6px 10px",
+        borderRadius: 999,
+        background: bg,
+        border: `1px solid ${border}`,
+        fontSize: 12,
+        fontWeight: 700,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+/* Styles */
+const stack: React.CSSProperties = { display: "grid", gap: 14 }
+
+const kpiGrid: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  gap: 12,
+}
+
+const kpi: React.CSSProperties = {
   background: "#fff",
   borderRadius: 16,
-  padding: 20,
+  padding: 16,
   border: "1px solid rgba(15,23,42,0.08)",
 }
 
-const h3: React.CSSProperties = {
-  margin: 0,
-  fontSize: 18,
+const kpiTitle: React.CSSProperties = {
+  fontSize: 12,
+  color: "rgba(15,23,42,0.6)",
+  fontWeight: 700,
+}
+
+const kpiValue: React.CSSProperties = {
+  marginTop: 6,
+  fontSize: 20,
+  fontWeight: 800,
+}
+
+const bar: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 16,
+  padding: 12,
+  border: "1px solid rgba(15,23,42,0.08)",
+  display: "flex",
+  gap: 12,
+  alignItems: "center",
+  justifyContent: "space-between",
+  flexWrap: "wrap",
+}
+
+const barLeft: React.CSSProperties = {
+  display: "flex",
+  gap: 10,
+  alignItems: "center",
+  flexWrap: "wrap",
+}
+
+const barRight: React.CSSProperties = {
+  display: "flex",
+  gap: 10,
+  alignItems: "center",
+}
+
+const search: React.CSSProperties = {
+  height: 42,
+  borderRadius: 12,
+  border: "1px solid rgba(15,23,42,0.12)",
+  background: "rgba(15,23,42,0.03)",
+  padding: "0 12px",
+  outline: "none",
+  width: 320,
+  maxWidth: "72vw",
+}
+
+const select: React.CSSProperties = {
+  height: 42,
+  borderRadius: 12,
+  border: "1px solid rgba(15,23,42,0.12)",
+  background: "rgba(15,23,42,0.03)",
+  padding: "0 10px",
+  outline: "none",
+}
+
+const card: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 16,
+  border: "1px solid rgba(15,23,42,0.08)",
+  overflow: "hidden",
+}
+
+const cardHead: React.CSSProperties = {
+  padding: 14,
+  borderBottom: "1px solid rgba(15,23,42,0.08)",
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+  gap: 10,
+  flexWrap: "wrap",
 }
 
 const muted: React.CSSProperties = {
   color: "rgba(15,23,42,0.6)",
-  marginTop: 6,
+  fontSize: 13,
 }
 
-const emptyState: React.CSSProperties = {
-  marginTop: 20,
-  padding: 24,
-  borderRadius: 12,
-  background: "rgba(15,23,42,0.03)",
+const table: React.CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+}
+
+const th: React.CSSProperties = {
+  textAlign: "left",
+  fontSize: 12,
+  color: "rgba(15,23,42,0.6)",
+  padding: "12px 14px",
+  borderBottom: "1px solid rgba(15,23,42,0.08)",
+  fontWeight: 800,
+  whiteSpace: "nowrap",
+}
+
+const thRight: React.CSSProperties = { ...th, textAlign: "right" }
+
+const tr: React.CSSProperties = {
+  cursor: "pointer",
+  transition: "background 160ms ease, transform 160ms ease",
+}
+
+const td: React.CSSProperties = {
+  padding: "12px 14px",
+  borderBottom: "1px solid rgba(15,23,42,0.06)",
+  fontSize: 14,
+  whiteSpace: "nowrap",
+}
+
+const tdStrong: React.CSSProperties = { ...td, fontWeight: 800 }
+
+const tdMono: React.CSSProperties = {
+  ...td,
+  fontFamily:
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+  fontSize: 13,
+  color: "rgba(15,23,42,0.8)",
+}
+
+const tdRight: React.CSSProperties = { ...td, textAlign: "right", fontWeight: 700 }
+
+const tdEmpty: React.CSSProperties = {
+  padding: 18,
   textAlign: "center",
+  color: "rgba(15,23,42,0.6)",
+}
+
+const ghostBtn: React.CSSProperties = {
+  height: 42,
+  padding: "0 14px",
+  borderRadius: 12,
+  border: "1px solid rgba(15,23,42,0.12)",
+  background: "#fff",
+  fontWeight: 700,
+}
+
+const primaryBtn: React.CSSProperties = {
+  height: 42,
+  padding: "0 14px",
+  borderRadius: 12,
+  border: "1px solid rgba(10,132,255,0.25)",
+  background: "rgba(10,132,255,0.12)",
+  fontWeight: 800,
 }


### PR DESCRIPTION
## Summary
- add subscriptions data helper backed by the Apps Script Sheets endpoint
- build real subscriptions list and detail pages with filtering, KPIs, and navigation
- hook subscriptions routes into the app and support renewals search prefill from detail

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ff3323a48328b8433a1024a95ca1)