### PR TITLE
Fix subscription detail navigation

### DIFF
--- a/src/pages/SubscriptionDetail.tsx
+++ b/src/pages/SubscriptionDetail.tsx
@@ -20,7 +20,7 @@ export default function SubscriptionDetail() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const entitlementId = params.get("id")?.trim() || ""
+  const subscriptionId = params.get("id")?.trim() || ""
 
   useEffect(() => {
     let active = true
@@ -50,19 +50,20 @@ export default function SubscriptionDetail() {
   }, [])
 
   const match = useMemo(() => {
-    if (!entitlementId) return null
-    const needle = entitlementId.toLowerCase()
+    if (!subscriptionId) return null
+    const needle = subscriptionId.toLowerCase()
 
     return (
       rows.find((row) => row.entitlementId.toLowerCase() === needle) ||
+      rows.find((row) => row.externalSubscriptionId?.toLowerCase() === needle) ||
       rows.find((row) => row.raw.entitlement_id?.toLowerCase?.() === needle) ||
       rows.find((row) => row.raw.Entitlement_ID?.toLowerCase?.() === needle) ||
       null
     )
-  }, [entitlementId, rows])
+  }, [subscriptionId, rows])
 
   const statusTone = deriveTone(match?.status)
-  const primaryId = match?.entitlementId || entitlementId || "Subscription"
+  const primaryId = subscriptionId || match?.entitlementId || "Subscription"
 
   const actions = (
     <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
@@ -70,7 +71,7 @@ export default function SubscriptionDetail() {
       <button
         className="cs-btn"
         onClick={() => {
-          const q = match?.entitlementId || entitlementId
+          const q = match?.entitlementId || subscriptionId
           nav(`/renewals?search=${encodeURIComponent(q)}`, { state: { search: q } })
         }}
       >
@@ -121,11 +122,11 @@ export default function SubscriptionDetail() {
 
           {loading && <div style={muted}>Loading subscription…</div>}
           {!loading && error && <div style={errorText}>{error}</div>}
-          {!loading && !error && !entitlementId && (
+          {!loading && !error && !subscriptionId && (
             <div style={errorText}>Missing subscription id.</div>
           )}
-          {!loading && !error && entitlementId && !match && (
-            <div style={errorText}>Subscription not found for ID: {entitlementId}</div>
+          {!loading && !error && subscriptionId && !match && (
+            <div style={errorText}>Subscription not found for ID: {subscriptionId}</div>
           )}
 
           {!loading && !error && match && (

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -207,31 +207,38 @@ export default function Subscriptions() {
                 )}
 
                 {!loading && !error &&
-                  filtered.map((row) => (
-                    <tr
-                      key={row.entitlementId}
-                      style={tr}
-                      onClick={() => nav(`/subscriptions/detail?id=${encodeURIComponent(row.entitlementId)}`)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          nav(`/subscriptions/detail?id=${encodeURIComponent(row.entitlementId)}`)
-                        }
-                      }}
-                      role="button"
-                      tabIndex={0}
-                      title="Open subscription detail"
-                    >
-                      <td style={tdMono}>{row.entitlementId}</td>
-                      <td style={tdStrong}>{row.vendorId}</td>
-                      <td style={td}>{row.productName}</td>
-                      <td style={td}>{row.planName}</td>
-                      <td style={td}>
-                        <Badge tone={deriveTone(row.status)}>{row.status || "Unknown"}</Badge>
-                      </td>
-                      <td style={tdMono}>{row.endDate || "—"}</td>
-                      <td style={tdRight}>{row.quantity ?? "—"}</td>
-                    </tr>
-                  ))}
+                  filtered.map((row) => {
+                    const id = row.externalSubscriptionId?.trim() || row.entitlementId
+
+                    const goToDetail = () =>
+                      nav(`/subscriptions/detail?id=${encodeURIComponent(id)}`)
+
+                    return (
+                      <tr
+                        key={row.entitlementId}
+                        style={tr}
+                        onClick={goToDetail}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            goToDetail()
+                          }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        title="Open subscription detail"
+                      >
+                        <td style={tdMono}>{row.entitlementId}</td>
+                        <td style={tdStrong}>{row.vendorId}</td>
+                        <td style={td}>{row.productName}</td>
+                        <td style={td}>{row.planName}</td>
+                        <td style={td}>
+                          <Badge tone={deriveTone(row.status)}>{row.status || "Unknown"}</Badge>
+                        </td>
+                        <td style={tdMono}>{row.endDate || "—"}</td>
+                        <td style={tdRight}>{row.quantity ?? "—"}</td>
+                      </tr>
+                    )
+                  })}
 
                 {!loading && !error && filtered.length === 0 && (
                   <tr>


### PR DESCRIPTION
## Summary
- update subscription list navigation to include subscription id query parameters derived from external or entitlement identifiers
- adjust subscription detail page to read the id from query params, look up entitlements by either external or entitlement id, and display requested id states

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69551241ff8c8328b77d0e44fae6d40c)