### PR TITLE
Add hover-expand sidebar and darken tenant onboarding

### DIFF
--- a/src/layout/AppShell.tsx
+++ b/src/layout/AppShell.tsx
@@ -11,7 +11,8 @@ export type AppShellProps = {
 }
 
 export default function AppShell({ title, subtitle, actions, children }: AppShellProps) {
-  const [collapsed, setCollapsed] = useState(true)
+  const [isPinned, setIsPinned] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
 
   const navItems = useMemo(
     () => [
@@ -48,7 +49,8 @@ export default function AppShell({ title, subtitle, actions, children }: AppShel
     [],
   )
 
-  const sidebarWidth = collapsed ? 72 : 240
+  const expanded = isPinned || isHovered
+  const sidebarWidth = expanded ? 240 : 72
 
   const shellStyle = useMemo<CSSProperties>(
     () => ({
@@ -60,32 +62,50 @@ export default function AppShell({ title, subtitle, actions, children }: AppShel
 
   return (
     <div style={shellStyle}>
-      <aside style={{ ...sidebar, width: sidebarWidth }}>
+      <aside
+        style={{ ...sidebar, width: sidebarWidth }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => {
+          if (!isPinned) setIsHovered(false)
+        }}
+      >
         <div style={brand}>
           <div style={brandRow}>
             <div style={brandName}>CS</div>
             <button
               className="cs-btn cs-btn-ghost"
               style={toggle}
-              aria-label={collapsed ? "Expand navigation" : "Collapse navigation"}
-              onClick={() => setCollapsed((v) => !v)}
+              aria-label={expanded ? "Collapse navigation" : "Expand navigation"}
+              onClick={() => setIsPinned((v) => {
+                const next = !v
+                if (!next) setIsHovered(false)
+                return next
+              })}
             >
-              {collapsed ? "→" : "←"}
+              <span
+                style={{
+                  display: "inline-block",
+                  transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                  transition: "transform 200ms ease",
+                }}
+              >
+                ➜
+              </span>
             </button>
           </div>
-          {!collapsed && <div style={brandSub}>CoreSight — Enterprise control</div>}
+          {expanded && <div style={brandSub}>CoreSight — Enterprise control</div>}
         </div>
 
         {navItems.map((section) => (
           <div key={section.label} style={{ marginBottom: 12 }}>
-            {!collapsed && <div style={navSectionTitle}>{section.label}</div>}
+            {expanded && <div style={navSectionTitle}>{section.label}</div>}
             {section.items.map((item) => (
-              <SideLink key={item.to} to={item.to} label={item.label} icon={item.icon} collapsed={collapsed} />
+              <SideLink key={item.to} to={item.to} label={item.label} icon={item.icon} collapsed={!expanded} />
             ))}
           </div>
         ))}
 
-        {!collapsed && (
+        {expanded && (
           <div style={tipCard}>
             <div style={{ fontWeight: 800, marginBottom: 6, color: "var(--text)" }}>Boardroom ready</div>
             <div style={{ color: "var(--muted)", lineHeight: 1.45 }}>

--- a/src/pages/admin/VendorNew.tsx
+++ b/src/pages/admin/VendorNew.tsx
@@ -314,7 +314,12 @@ export default function VendorNew() {
 
                 <Field label="Demo tenant">
                   <div style={checkRow}>
-                    <input type="checkbox" checked={is_demo_tenant} onChange={(e) => setIsDemoTenant(e.target.checked)} />
+                    <input
+                      type="checkbox"
+                      style={checkbox}
+                      checked={is_demo_tenant}
+                      onChange={(e) => setIsDemoTenant(e.target.checked)}
+                    />
                     <span style={mutedSmall}>Mark as demo</span>
                   </div>
                 </Field>
@@ -370,28 +375,48 @@ export default function VendorNew() {
 
                 <Field label="Compliance Flag">
                   <div style={checkRow}>
-                    <input type="checkbox" checked={compliance_flag} onChange={(e) => setComplianceFlag(e.target.checked)} />
+                    <input
+                      type="checkbox"
+                      style={checkbox}
+                      checked={compliance_flag}
+                      onChange={(e) => setComplianceFlag(e.target.checked)}
+                    />
                     <span style={mutedSmall}>Requires compliance review</span>
                   </div>
                 </Field>
 
                 <Field label="AI Insights Enabled">
                   <div style={checkRow}>
-                    <input type="checkbox" checked={ai_insights_enabled} onChange={(e) => setAI(e.target.checked)} />
+                    <input
+                      type="checkbox"
+                      style={checkbox}
+                      checked={ai_insights_enabled}
+                      onChange={(e) => setAI(e.target.checked)}
+                    />
                     <span style={mutedSmall}>Enable</span>
                   </div>
                 </Field>
 
                 <Field label="Cost Optimization Enabled">
                   <div style={checkRow}>
-                    <input type="checkbox" checked={cost_optimization_enabled} onChange={(e) => setCost(e.target.checked)} />
+                    <input
+                      type="checkbox"
+                      style={checkbox}
+                      checked={cost_optimization_enabled}
+                      onChange={(e) => setCost(e.target.checked)}
+                    />
                     <span style={mutedSmall}>Enable</span>
                   </div>
                 </Field>
 
                 <Field label="Usage Analytics Enabled">
                   <div style={checkRow}>
-                    <input type="checkbox" checked={usage_analytics_enabled} onChange={(e) => setAnalytics(e.target.checked)} />
+                    <input
+                      type="checkbox"
+                      style={checkbox}
+                      checked={usage_analytics_enabled}
+                      onChange={(e) => setAnalytics(e.target.checked)}
+                    />
                     <span style={mutedSmall}>Enable</span>
                   </div>
                 </Field>
@@ -460,7 +485,7 @@ export default function VendorNew() {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 0 }}>
-      <div style={{ fontSize: 13, fontWeight: 600 }}>{label}</div>
+      <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{label}</div>
       {children}
     </div>
   )
@@ -491,13 +516,13 @@ const wrap: React.CSSProperties = {
   width: "100%",
   maxWidth: 1200,
   margin: "0 auto",
-  padding: 6,
+  padding: 12,
 }
 const card: React.CSSProperties = {
   width: "100%",
-  background: "var(--surface)",
+  background: "linear-gradient(145deg, #161a20, #13161d)",
   border: "1px solid var(--border)",
-  borderRadius: 18,
+  borderRadius: 14,
   padding: 20,
   boxShadow: "var(--shadow-soft)",
 }
@@ -516,7 +541,7 @@ const grid2: React.CSSProperties = {
   gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
   gap: 16,
 }
-const h2: React.CSSProperties = { margin: "6px 0 0", fontSize: 18 }
+const h2: React.CSSProperties = { margin: "6px 0 0", fontSize: 18, color: "var(--text)" }
 const muted: React.CSSProperties = { margin: "6px 0 14px", color: "var(--muted)" }
 const mutedSmall: React.CSSProperties = { color: "var(--muted)", fontSize: 13 }
 const checkRow: React.CSSProperties = { display: "flex", alignItems: "center", gap: 10, height: 44 }
@@ -532,6 +557,15 @@ const primaryBtnSmall: React.CSSProperties = {
   padding: "0 16px",
   borderRadius: 12,
   fontWeight: 700,
+}
+const checkbox: React.CSSProperties = {
+  width: 18,
+  height: 18,
+  accentColor: "var(--accent)",
+  background: "var(--surface-elevated)",
+  borderRadius: 6,
+  border: "1px solid var(--border)",
+  boxShadow: "0 0 0 1px rgba(0,0,0,0.4)",
 }
 const errorBox: React.CSSProperties = {
   marginTop: 14,


### PR DESCRIPTION
## Summary
- add hover-expand and pin toggle to the sidebar while keeping icon-first default
- animate label visibility and tip card only when expanded and update layout sizing
- restyle the Onboard Tenant wizard to match the dark CoreSight palette, including checkboxes and container surfaces

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69567234ef0c8328b7808054c708c2b8)