### PR TITLE
Add admin and customer portal flows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,133 +1,135 @@
 // src/App.tsx
-import { HashRouter, Routes, Route, Navigate } from "react-router-dom"
+import type { ReactElement } from "react"
+import { HashRouter, Navigate, Route, Routes } from "react-router-dom"
+import Landing from "./pages/Landing"
+import AdminLogin from "./pages/AdminLogin"
+import CustomerLogin from "./pages/CustomerLogin"
+import AdminTenants from "./pages/admin/AdminTenants"
+import AdminTenantForm from "./pages/admin/AdminTenantForm"
+import AdminUsers from "./pages/admin/AdminUsers"
+import AdminSettings from "./pages/admin/AdminSettings"
+import CustomerDashboard from "./pages/customer/Dashboard"
+import CustomerReports from "./pages/customer/Reports"
+import CustomerDepartments from "./pages/customer/Departments"
+import CustomerAnalytics from "./pages/customer/Analytics"
+import CustomerAIInsights from "./pages/customer/AIInsights"
+import CustomerSettings from "./pages/customer/Settings"
+import { useAdminAuth } from "./auth/AdminAuthContext"
+import { useCustomerAuth } from "./auth/CustomerAuthContext"
 
-// Real pages (these DO exist)
-import Home from "./pages/Home"
-import Dashboard from "./pages/Dashboard"
-import Reports from "./pages/Reports"
-import Approvals from "./pages/Approvals"
+function AdminGuard({ children }: { children: ReactElement }) {
+  const { isAuthenticated } = useAdminAuth()
+  if (!isAuthenticated) return <Navigate to="/admin/login" replace />
+  return children
+}
 
-// Real pages
-import Renewals from "./pages/Renewals"
-import RenewalDetail from "./pages/RenewalDetail"
-import Subscriptions from "./pages/Subscriptions"
-import SubscriptionDetail from "./pages/SubscriptionDetail"
-
-// Existing admin pages
-import Vendors from "./pages/admin/Vendors"
-import VendorNew from "./pages/admin/VendorNew"
-import Settings from "./pages/admin/Settings"
-
-// Placeholders (stubs for pages not built yet)
-import { PlaceholderPage } from "./pages/_placeholders"
+function CustomerGuard({ children }: { children: ReactElement }) {
+  const { isAuthenticated } = useCustomerAuth()
+  if (!isAuthenticated) return <Navigate to="/customer/login" replace />
+  return children
+}
 
 export default function App() {
   return (
     <HashRouter>
       <Routes>
-        {/* Default */}
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/" element={<Landing />} />
 
-        {/* Core */}
-        <Route path="/home" element={<Home />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/reports" element={<Reports />} />
+        <Route path="/admin/login" element={<AdminLogin />} />
         <Route
-          path="/analytics"
+          path="/admin/tenants"
           element={
-            <PlaceholderPage
-              title="Analytics Dashboard"
-              subtitle="Usage, adoption, and performance metrics"
-            />
+            <AdminGuard>
+              <AdminTenants />
+            </AdminGuard>
           }
         />
         <Route
-          path="/ai-insights"
+          path="/admin/tenants/new"
           element={
-            <PlaceholderPage
-              title="AI Insights"
-              subtitle="Foresight, signals, and recommendations (coming soon)"
-            />
-          }
-        />
-
-        {/* Auth / selection */}
-        <Route
-          path="/login"
-          element={<PlaceholderPage title="Login" subtitle="SSO + email login (demo stub)" />}
-        />
-        <Route
-          path="/tenant-selection"
-          element={<PlaceholderPage title="Tenant Selection" subtitle="Choose tenant and role" />}
-        />
-
-        {/* Setup */}
-        <Route path="/company-setup" element={<PlaceholderPage title="Company Setup" />} />
-        <Route path="/department-setup" element={<PlaceholderPage title="Department Setup" />} />
-        <Route
-          path="/connect-sources"
-          element={
-            <PlaceholderPage
-              title="Connect Data Sources"
-              subtitle="Google Sheets / CRM / ERP connectors"
-            />
+            <AdminGuard>
+              <AdminTenantForm />
+            </AdminGuard>
           }
         />
         <Route
-          path="/sync-progress"
-          element={<PlaceholderPage title="Sync Progress" subtitle="Live progress + error handling" />}
-        />
-
-        {/* Subscriptions */}
-        <Route path="/subscriptions" element={<Subscriptions />} />
-        <Route path="/subscriptions/detail" element={<SubscriptionDetail />} />
-
-        {/* Users / identity */}
-        <Route path="/users" element={<PlaceholderPage title="Users List" />} />
-        <Route path="/users/profile" element={<PlaceholderPage title="User Profile" />} />
-        <Route
-          path="/identity-queue"
+          path="/admin/tenants/:tenantId/edit"
           element={
-            <PlaceholderPage
-              title="Identity Resolution Queue"
-              subtitle="Merge/split identities + review actions"
-            />
+            <AdminGuard>
+              <AdminTenantForm />
+            </AdminGuard>
           }
         />
-        <Route path="/departments" element={<PlaceholderPage title="Departments Overview" />} />
-
-        {/* Vendors / admin onboarding (REAL) */}
-        <Route path="/admin/vendors" element={<Vendors />} />
-        <Route path="/admin/vendor-new" element={<VendorNew />} />
-        <Route path="/admin/settings" element={<Settings />} />
-
-        {/* Renewals (REAL) */}
-        <Route path="/renewals" element={<Renewals />} />
-        <Route path="/renewals/detail" element={<RenewalDetail />} />
-
-        {/* Approvals (REAL) */}
-        <Route path="/approvals" element={<Approvals />} />
-
-        {/* Audit log (stub for now) */}
         <Route
-          path="/audit-log"
+          path="/admin/users"
           element={
-            <PlaceholderPage
-              title="Audit Log"
-              subtitle="All actions are tracked here (demo log next)"
-            />
+            <AdminGuard>
+              <AdminUsers />
+            </AdminGuard>
           }
         />
-
-        {/* Policies / settings */}
-        <Route path="/tenant-settings" element={<PlaceholderPage title="Tenant Settings" />} />
         <Route
-          path="/policies"
-          element={<PlaceholderPage title="Policies" subtitle="Security + retention + data governance" />}
+          path="/admin/settings"
+          element={
+            <AdminGuard>
+              <AdminSettings />
+            </AdminGuard>
+          }
         />
+        <Route path="/admin" element={<Navigate to="/admin/tenants" replace />} />
 
-        {/* Fallback */}
-        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/customer/login" element={<CustomerLogin />} />
+        <Route
+          path="/app/dashboard"
+          element={
+            <CustomerGuard>
+              <CustomerDashboard />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/reports"
+          element={
+            <CustomerGuard>
+              <CustomerReports />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/departments"
+          element={
+            <CustomerGuard>
+              <CustomerDepartments />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/analytics"
+          element={
+            <CustomerGuard>
+              <CustomerAnalytics />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/ai-insights"
+          element={
+            <CustomerGuard>
+              <CustomerAIInsights />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/settings"
+          element={
+            <CustomerGuard>
+              <CustomerSettings />
+            </CustomerGuard>
+          }
+        />
+        <Route path="/app" element={<Navigate to="/app/dashboard" replace />} />
+
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </HashRouter>
   )

--- a/src/auth/AdminAuthContext.tsx
+++ b/src/auth/AdminAuthContext.tsx
@@ -1,0 +1,82 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react"
+import { ensureSeedAdmin, getAdminEmail, getAdminPassword } from "../data/users"
+import type { User } from "../data/users"
+import { readStorage, writeStorage } from "../lib/storage"
+
+const STORAGE_KEY = "coresight_admin_session"
+
+type AdminSession = {
+  user: User
+}
+
+type LoginResult = { success: boolean; error?: string }
+
+type AdminAuthContextValue = {
+  currentUser?: User
+  login: (email: string, password: string) => LoginResult
+  logout: () => void
+  isAuthenticated: boolean
+}
+
+const AdminAuthContext = createContext<AdminAuthContextValue | undefined>(undefined)
+
+export function AdminAuthProvider({ children }: { children: React.ReactNode }) {
+  const [currentUser, setCurrentUser] = useState<User | undefined>(undefined)
+
+  useEffect(() => {
+    ensureSeedAdmin()
+    const stored = readStorage<AdminSession | undefined>(STORAGE_KEY, undefined)
+    if (stored?.user) {
+      setCurrentUser(stored.user)
+    }
+  }, [])
+
+  const login = (email: string, password: string): LoginResult => {
+    const normalizedEmail = email.trim().toLowerCase()
+    const expectedEmail = getAdminEmail().toLowerCase()
+    const expectedPassword = getAdminPassword()
+
+    if (normalizedEmail !== expectedEmail) {
+      return { success: false, error: "Invalid credentials" }
+    }
+    if (password !== expectedPassword) {
+      return { success: false, error: "Invalid credentials" }
+    }
+
+    const sessionUser: User = {
+      user_id: "admin",
+      email: expectedEmail,
+      password_hash: "", // not stored for session
+      role: "ADMIN",
+      status: "Active",
+      created_at: "",
+      updated_at: "",
+    }
+    setCurrentUser(sessionUser)
+    writeStorage(STORAGE_KEY, { user: sessionUser })
+    return { success: true }
+  }
+
+  const logout = () => {
+    setCurrentUser(undefined)
+    writeStorage(STORAGE_KEY, undefined)
+  }
+
+  const value = useMemo(
+    () => ({
+      currentUser,
+      login,
+      logout,
+      isAuthenticated: Boolean(currentUser),
+    }),
+    [currentUser],
+  )
+
+  return <AdminAuthContext.Provider value={value}>{children}</AdminAuthContext.Provider>
+}
+
+export function useAdminAuth() {
+  const ctx = useContext(AdminAuthContext)
+  if (!ctx) throw new Error("useAdminAuth must be used inside AdminAuthProvider")
+  return ctx
+}

--- a/src/auth/CustomerAuthContext.tsx
+++ b/src/auth/CustomerAuthContext.tsx
@@ -1,0 +1,94 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react"
+import { findCustomerUser, hashPassword, listUsers, verifyPassword } from "../data/users"
+import { getTenantByCode, listTenants } from "../data/tenants"
+import type { Tenant } from "../data/tenants"
+import type { User } from "../data/users"
+import { readStorage, writeStorage } from "../lib/storage"
+
+const STORAGE_KEY = "coresight_customer_session"
+
+export type CustomerSession = {
+  user: User
+  tenant: Tenant
+}
+
+type LoginResult = { success: boolean; error?: string }
+
+type CustomerAuthValue = {
+  tenant?: Tenant
+  user?: User
+  isAuthenticated: boolean
+  login: (tenantCode: string, email: string, password: string) => LoginResult
+  logout: () => void
+}
+
+const CustomerAuthContext = createContext<CustomerAuthValue | undefined>(undefined)
+
+export function CustomerAuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<CustomerSession | undefined>(undefined)
+
+  useEffect(() => {
+    const stored = readStorage<CustomerSession | undefined>(STORAGE_KEY, undefined)
+    if (stored?.tenant && stored?.user) {
+      setSession(stored)
+    }
+  }, [])
+
+  const login = (tenantCode: string, email: string, password: string): LoginResult => {
+    const tenant = getTenantByCode(tenantCode.trim())
+    if (!tenant) return { success: false, error: "Tenant not found" }
+    if (tenant.status !== "Active") return { success: false, error: "Tenant inactive" }
+
+    const user = findCustomerUser(tenant, email.trim())
+    if (!user) return { success: false, error: "User not found" }
+    if (user.status !== "Active") return { success: false, error: "User inactive" }
+
+    if (!verifyPassword(password, user.password_hash)) {
+      return { success: false, error: "Incorrect password" }
+    }
+
+    const newSession: CustomerSession = { tenant, user }
+    setSession(newSession)
+    writeStorage(STORAGE_KEY, newSession)
+    return { success: true }
+  }
+
+  const logout = () => {
+    setSession(undefined)
+    writeStorage(STORAGE_KEY, undefined)
+  }
+
+  const value = useMemo(
+    () => ({ tenant: session?.tenant, user: session?.user, isAuthenticated: Boolean(session), login, logout }),
+    [session],
+  )
+
+  return <CustomerAuthContext.Provider value={value}>{children}</CustomerAuthContext.Provider>
+}
+
+export function useCustomerAuth() {
+  const ctx = useContext(CustomerAuthContext)
+  if (!ctx) throw new Error("useCustomerAuth must be used inside CustomerAuthProvider")
+  return ctx
+}
+
+// Helper seeds for demo convenience
+export function seedDemoUsers() {
+  const tenants = listTenants()
+  const users = listUsers()
+  const hasCustomer = users.some((u) => u.role !== "ADMIN")
+  if (tenants.length === 0 || hasCustomer) return
+  const tenant = tenants[0]
+  // Only seed a single demo user when storage is empty
+  const demoUser: User = {
+    user_id: "demo-user",
+    tenant_id: tenant.tenant_id,
+    email: "primary@demo.corp",
+    password_hash: hashPassword("demo123"),
+    role: "CUSTOMER_PRIMARY",
+    status: "Active",
+    created_at: tenant.created_at,
+    updated_at: tenant.created_at,
+  }
+  writeStorage("coresight_users", [...users, demoUser])
+}

--- a/src/data/tenants.ts
+++ b/src/data/tenants.ts
@@ -1,0 +1,97 @@
+// src/data/tenants.ts
+import { generateId, nowIso, readStorage, writeStorage } from "../lib/storage"
+
+export type TenantStatus = "Active" | "Inactive"
+export type Tenant = {
+  tenant_id: string
+  tenant_code: string
+  tenant_name: string
+  legal_name?: string
+  tenant_type?: string
+  region?: string
+  timezone?: string
+  currency?: string
+  subscription?: string
+  status: TenantStatus
+  created_at: string
+  updated_at: string
+}
+
+const STORAGE_KEY = "coresight_tenants"
+
+export function listTenants(): Tenant[] {
+  return readStorage<Tenant[]>(STORAGE_KEY, [])
+}
+
+function persistTenants(next: Tenant[]) {
+  writeStorage(STORAGE_KEY, next)
+}
+
+export function getTenant(id: string) {
+  return listTenants().find((t) => t.tenant_id === id)
+}
+
+export function getTenantByCode(code: string) {
+  return listTenants().find((t) => t.tenant_code.toLowerCase() === code.toLowerCase())
+}
+
+export type TenantInput = Omit<Tenant, "tenant_id" | "created_at" | "updated_at" | "status"> & {
+  status?: TenantStatus
+}
+
+export function createTenant(payload: TenantInput): Tenant {
+  const now = nowIso()
+  const tenant: Tenant = {
+    tenant_id: generateId("tenant"),
+    tenant_code: payload.tenant_code,
+    tenant_name: payload.tenant_name,
+    legal_name: payload.legal_name ?? payload.tenant_name,
+    tenant_type: payload.tenant_type ?? "Enterprise",
+    region: payload.region ?? "Global",
+    timezone: payload.timezone ?? "UTC",
+    currency: payload.currency ?? "USD",
+    subscription: payload.subscription ?? "Enterprise",
+    status: payload.status ?? "Active",
+    created_at: now,
+    updated_at: now,
+  }
+
+  const next = [...listTenants(), tenant]
+  persistTenants(next)
+  return tenant
+}
+
+export function updateTenant(id: string, changes: Partial<Tenant>): Tenant | undefined {
+  let updated: Tenant | undefined
+  const next = listTenants().map((tenant) => {
+    if (tenant.tenant_id !== id) return tenant
+    updated = {
+      ...tenant,
+      ...changes,
+      tenant_id: tenant.tenant_id,
+      updated_at: nowIso(),
+    }
+    return updated
+  })
+  if (updated) persistTenants(next)
+  return updated
+}
+
+export function setTenantStatus(id: string, status: TenantStatus) {
+  return updateTenant(id, { status })
+}
+
+export function ensureSeedTenant() {
+  if (listTenants().length > 0) return
+  createTenant({
+    tenant_code: "acme",
+    tenant_name: "Acme Holdings",
+    legal_name: "Acme Holdings LLC",
+    tenant_type: "Demo Enterprise",
+    region: "USA",
+    timezone: "UTC",
+    currency: "USD",
+    subscription: "Pilot",
+    status: "Active",
+  })
+}

--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -1,0 +1,119 @@
+// src/data/users.ts
+import { generateId, nowIso, readStorage, writeStorage } from "../lib/storage"
+import type { Tenant } from "./tenants"
+
+export type UserRole = "ADMIN" | "CUSTOMER_PRIMARY" | "CUSTOMER_USER"
+export type UserStatus = "Active" | "Inactive"
+
+export type User = {
+  user_id: string
+  tenant_id?: string
+  email: string
+  password_hash: string
+  role: UserRole
+  status: UserStatus
+  created_at: string
+  updated_at: string
+}
+
+const STORAGE_KEY = "coresight_users"
+
+export function hashPassword(password: string) {
+  try {
+    return btoa(unescape(encodeURIComponent(password)))
+  } catch {
+    return password
+  }
+}
+
+export function verifyPassword(password: string, hash: string) {
+  return hashPassword(password) === hash
+}
+
+export function listUsers(): User[] {
+  return readStorage<User[]>(STORAGE_KEY, [])
+}
+
+function persist(next: User[]) {
+  writeStorage(STORAGE_KEY, next)
+}
+
+export function listUsersByTenant(tenantId: string) {
+  return listUsers().filter((u) => u.tenant_id === tenantId)
+}
+
+export function findUserByEmail(email: string) {
+  return listUsers().find((u) => u.email.toLowerCase() === email.toLowerCase())
+}
+
+export function findCustomerUser(tenant: Tenant, email: string) {
+  return listUsers().find(
+    (u) =>
+      u.tenant_id === tenant.tenant_id &&
+      u.email.toLowerCase() === email.toLowerCase() &&
+      (u.role === "CUSTOMER_PRIMARY" || u.role === "CUSTOMER_USER"),
+  )
+}
+
+export type CreateUserPayload = {
+  tenant_id?: string
+  email: string
+  password: string
+  role: UserRole
+  status?: UserStatus
+}
+
+export function createUser(payload: CreateUserPayload): User {
+  const now = nowIso()
+  const user: User = {
+    user_id: generateId("user"),
+    tenant_id: payload.tenant_id,
+    email: payload.email,
+    password_hash: hashPassword(payload.password),
+    role: payload.role,
+    status: payload.status ?? "Active",
+    created_at: now,
+    updated_at: now,
+  }
+  const next = [...listUsers(), user]
+  persist(next)
+  return user
+}
+
+export function updateUser(id: string, changes: Partial<User>) {
+  let updated: User | undefined
+  const next = listUsers().map((u) => {
+    if (u.user_id !== id) return u
+    updated = {
+      ...u,
+      ...changes,
+      user_id: u.user_id,
+      updated_at: nowIso(),
+    }
+    return updated
+  })
+  if (updated) persist(next)
+  return updated
+}
+
+export function resetPassword(userId: string, password: string) {
+  return updateUser(userId, { password_hash: hashPassword(password) })
+}
+
+export function ensureSeedAdmin() {
+  if (findUserByEmail(getAdminEmail())) return
+  createUser({
+    email: getAdminEmail(),
+    password: getAdminPassword(),
+    role: "ADMIN",
+    status: "Active",
+  })
+}
+
+export function getAdminEmail() {
+  return import.meta.env.VITE_ADMIN_EMAIL || "admin@coresight.local"
+}
+
+export function getAdminPassword() {
+  return import.meta.env.VITE_ADMIN_PASSWORD || "admin123"
+}

--- a/src/layout/AppShell.tsx
+++ b/src/layout/AppShell.tsx
@@ -3,51 +3,25 @@ import { NavLink } from "react-router-dom"
 import { useMemo, useState } from "react"
 import type { ReactNode, CSSProperties } from "react"
 
+export type NavSection = {
+  label?: string
+  items: { to: string; label: string; icon: string }[]
+}
+
 export type AppShellProps = {
   title: string
   subtitle?: string
   actions?: ReactNode
   children: ReactNode
+  navSections?: NavSection[]
+  chips?: ReactNode[]
 }
 
-export default function AppShell({ title, subtitle, actions, children }: AppShellProps) {
+export default function AppShell({ title, subtitle, actions, children, navSections, chips }: AppShellProps) {
   const [isPinned, setIsPinned] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
 
-  const navItems = useMemo(
-    () => [
-      {
-        label: "Core",
-        items: [
-          { to: "/dashboard", label: "Dashboard", icon: "📊" },
-          { to: "/subscriptions", label: "Subscriptions", icon: "💳" },
-          { to: "/users", label: "Users", icon: "👥" },
-          { to: "/departments", label: "Departments", icon: "🏢" },
-          { to: "/analytics", label: "Analytics", icon: "📈" },
-          { to: "/ai-insights", label: "AI Insights", icon: "✨" },
-        ],
-      },
-      {
-        label: "Operations",
-        items: [
-          { to: "/approvals", label: "Approvals", icon: "✅" },
-          { to: "/renewals", label: "Renewals", icon: "↻" },
-          { to: "/subscriptions/detail", label: "Subscription Detail", icon: "◉" },
-          { to: "/renewals/detail", label: "Renewal Detail", icon: "○" },
-          { to: "/reports", label: "Reports", icon: "🗒" },
-        ],
-      },
-      {
-        label: "Admin",
-        items: [
-          { to: "/admin/vendors", label: "Tenants", icon: "🏢" },
-          { to: "/admin/vendor-new", label: "Onboard Tenant", icon: "＋" },
-          { to: "/admin/settings", label: "Admin / Settings", icon: "⚙" },
-        ],
-      },
-    ],
-    [],
-  )
+  const navItems = useMemo(() => navSections ?? defaultNav, [navSections])
 
   const expanded = isPinned || isHovered
   const sidebarWidth = expanded ? 240 : 72
@@ -124,8 +98,11 @@ export default function AppShell({ title, subtitle, actions, children }: AppShel
 
           <div style={topRight}>
             {actions ? <div style={actionsWrap}>{actions}</div> : null}
-            <span style={chip}>Env: PROD</span>
-            <span style={chip}>Region: KSA</span>
+            {(chips || defaultChips).map((chipNode, idx) => (
+              <span key={idx} style={chip}>
+                {chipNode}
+              </span>
+            ))}
           </div>
         </div>
 
@@ -312,3 +289,37 @@ const tipCard: CSSProperties = {
   background: "var(--surface)",
   boxShadow: "var(--shadow-sm)",
 }
+
+const defaultNav: NavSection[] = [
+  {
+    label: "Core",
+    items: [
+      { to: "/dashboard", label: "Dashboard", icon: "📊" },
+      { to: "/subscriptions", label: "Subscriptions", icon: "💳" },
+      { to: "/users", label: "Users", icon: "👥" },
+      { to: "/departments", label: "Departments", icon: "🏢" },
+      { to: "/analytics", label: "Analytics", icon: "📈" },
+      { to: "/ai-insights", label: "AI Insights", icon: "✨" },
+    ],
+  },
+  {
+    label: "Operations",
+    items: [
+      { to: "/approvals", label: "Approvals", icon: "✅" },
+      { to: "/renewals", label: "Renewals", icon: "↻" },
+      { to: "/subscriptions/detail", label: "Subscription Detail", icon: "◉" },
+      { to: "/renewals/detail", label: "Renewal Detail", icon: "○" },
+      { to: "/reports", label: "Reports", icon: "🗒" },
+    ],
+  },
+  {
+    label: "Admin",
+    items: [
+      { to: "/admin/vendors", label: "Tenants", icon: "🏢" },
+      { to: "/admin/vendor-new", label: "Onboard Tenant", icon: "＋" },
+      { to: "/admin/settings", label: "Admin / Settings", icon: "⚙" },
+    ],
+  },
+]
+
+const defaultChips = ["Env: PROD", "Region: KSA"]

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,39 @@
+// src/lib/storage.ts
+export const isBrowser = typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+
+export function readStorage<T>(key: string, fallback: T): T {
+  if (!isBrowser) return fallback
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return fallback
+    return JSON.parse(raw) as T
+  } catch (err) {
+    console.warn("Failed to read storage", err)
+    return fallback
+  }
+}
+
+export function writeStorage<T>(key: string, value: T) {
+  if (!isBrowser) return
+  try {
+    if (value === undefined || (value as unknown) === null) {
+      window.localStorage.removeItem(key)
+      return
+    }
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch (err) {
+    console.warn("Failed to write storage", err)
+  }
+}
+
+export function generateId(prefix: string) {
+  const core =
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  return `${prefix}_${core}`
+}
+
+export function nowIso() {
+  return new Date().toISOString()
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,15 @@ import React from "react"
 import ReactDOM from "react-dom/client"
 import App from "./App"
 import "./index.css"
+import { AdminAuthProvider } from "./auth/AdminAuthContext"
+import { CustomerAuthProvider } from "./auth/CustomerAuthContext"
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <AdminAuthProvider>
+      <CustomerAuthProvider>
+        <App />
+      </CustomerAuthProvider>
+    </AdminAuthProvider>
+  </React.StrictMode>,
 )

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react"
+import type { FormEvent } from "react"
+import { Navigate, useNavigate } from "react-router-dom"
+import { useAdminAuth } from "../auth/AdminAuthContext"
+
+export default function AdminLogin() {
+  const { login, isAuthenticated } = useAdminAuth()
+  const [email, setEmail] = useState("admin@coresight.local")
+  const [password, setPassword] = useState("admin123")
+  const [error, setError] = useState<string | undefined>()
+  const navigate = useNavigate()
+
+  if (isAuthenticated) return <Navigate to="/admin/tenants" replace />
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    const result = login(email, password)
+    if (!result.success) {
+      setError(result.error)
+      return
+    }
+    navigate("/admin/tenants")
+  }
+
+  return (
+    <div style={wrap}>
+      <div style={card}>
+        <p style={eyebrow}>Admin access</p>
+        <h2 style={title}>Administrator login</h2>
+        <p style={subtitle}>Use the prototype admin credentials. Update env vars to change.</p>
+
+        <form style={form} onSubmit={onSubmit}>
+          <label style={label}>
+            Email
+            <input className="cs-input" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="admin@coresight.local" />
+          </label>
+          <label style={label}>
+            Password
+            <input
+              className="cs-input"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="admin123"
+            />
+          </label>
+          {error ? <div style={errorBox}>{error}</div> : null}
+          <button className="cs-btn cs-btn-primary" type="submit">
+            Login as Admin
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+const wrap: React.CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "var(--background)",
+  padding: 24,
+}
+
+const card: React.CSSProperties = {
+  width: "min(480px, 100%)",
+  padding: 28,
+  borderRadius: 18,
+  border: "1px solid var(--border)",
+  background: "var(--surface-elevated)",
+  boxShadow: "var(--shadow-sm)",
+}
+
+const eyebrow: React.CSSProperties = { color: "var(--muted)", textTransform: "uppercase", letterSpacing: 3, fontWeight: 800, fontSize: 11 }
+const title: React.CSSProperties = { margin: "6px 0", fontSize: 26, letterSpacing: -0.4 }
+const subtitle: React.CSSProperties = { marginBottom: 16, color: "var(--text-secondary)" }
+
+const form: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 14 }
+const label: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 8, fontWeight: 700, color: "var(--text-secondary)" }
+const errorBox: React.CSSProperties = {
+  borderRadius: 12,
+  border: "1px solid rgba(255,255,255,0.12)",
+  background: "rgba(255, 90, 90, 0.08)",
+  padding: 10,
+  color: "#ffb4b4",
+  fontWeight: 700,
+}

--- a/src/pages/CustomerLogin.tsx
+++ b/src/pages/CustomerLogin.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react"
+import type { FormEvent } from "react"
+import { Navigate, useNavigate } from "react-router-dom"
+import { useCustomerAuth, seedDemoUsers } from "../auth/CustomerAuthContext"
+import { ensureSeedTenant } from "../data/tenants"
+
+export default function CustomerLogin() {
+  const { isAuthenticated, login } = useCustomerAuth()
+  const navigate = useNavigate()
+  const [tenantCode, setTenantCode] = useState("acme")
+  const [email, setEmail] = useState("primary@demo.corp")
+  const [password, setPassword] = useState("demo123")
+  const [error, setError] = useState<string | undefined>()
+
+  useEffect(() => {
+    ensureSeedTenant()
+    seedDemoUsers()
+  }, [])
+
+  if (isAuthenticated) return <Navigate to="/app/dashboard" replace />
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    const result = login(tenantCode, email, password)
+    if (!result.success) {
+      setError(result.error)
+      return
+    }
+    navigate("/app/dashboard")
+  }
+
+  return (
+    <div style={wrap}>
+      <div style={card}>
+        <p style={eyebrow}>Customer access</p>
+        <h2 style={title}>Tenant login</h2>
+        <p style={subtitle}>Enter the tenant code and credentials issued by your CoreSight admin.</p>
+
+        <form style={form} onSubmit={onSubmit}>
+          <label style={label}>
+            Tenant code
+            <input className="cs-input" value={tenantCode} onChange={(e) => setTenantCode(e.target.value)} placeholder="acme" />
+          </label>
+          <label style={label}>
+            Email
+            <input className="cs-input" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="primary@demo.corp" />
+          </label>
+          <label style={label}>
+            Password
+            <input
+              className="cs-input"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••"
+            />
+          </label>
+          {error ? <div style={errorBox}>{error}</div> : null}
+          <button className="cs-btn cs-btn-primary" type="submit">
+            Login to portal
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+const wrap: React.CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "var(--background)",
+  padding: 24,
+}
+
+const card: React.CSSProperties = {
+  width: "min(520px, 100%)",
+  padding: 28,
+  borderRadius: 18,
+  border: "1px solid var(--border)",
+  background: "var(--surface-elevated)",
+  boxShadow: "var(--shadow-sm)",
+}
+
+const eyebrow: React.CSSProperties = { color: "var(--muted)", textTransform: "uppercase", letterSpacing: 3, fontWeight: 800, fontSize: 11 }
+const title: React.CSSProperties = { margin: "6px 0", fontSize: 26, letterSpacing: -0.4 }
+const subtitle: React.CSSProperties = { marginBottom: 16, color: "var(--text-secondary)" }
+
+const form: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 14 }
+const label: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 8, fontWeight: 700, color: "var(--text-secondary)" }
+const errorBox: React.CSSProperties = {
+  borderRadius: 12,
+  border: "1px solid rgba(255,255,255,0.12)",
+  background: "rgba(255, 90, 90, 0.08)",
+  padding: 10,
+  color: "#ffb4b4",
+  fontWeight: 700,
+}

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,69 @@
+import { Link } from "react-router-dom"
+
+export default function Landing() {
+  return (
+    <div style={container}>
+      <div style={heroBox}>
+        <p style={eyebrow}>CoreSight Prototype</p>
+        <h1 style={title}>Choose your entry point</h1>
+        <p style={subtitle}>Boardroom-ready access for admins and customers. Dark-first, calm gradients.</p>
+
+        <div style={actions}>
+          <Link to="/customer/login" style={{ ...cta, background: "var(--accent)", color: "#041018" }}>
+            Customer Login
+          </Link>
+          <Link to="/admin/login" style={{ ...cta, border: "1px solid var(--border)", color: "var(--text)" }}>
+            Admin Login
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const container: React.CSSProperties = {
+  minHeight: "100vh",
+  background:
+    "radial-gradient(1200px 1200px at 20% 10%, rgba(77,163,255,0.14), transparent 40%)," +
+    "radial-gradient(1200px 1200px at 80% 0%, rgba(77,163,255,0.10), transparent 38%)," +
+    "var(--background)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 32,
+  color: "var(--text)",
+}
+
+const heroBox: React.CSSProperties = {
+  width: "min(720px, 100%)",
+  padding: 40,
+  borderRadius: 24,
+  border: "1px solid var(--border)",
+  background: "linear-gradient(180deg, rgba(22,26,32,0.96), rgba(16,18,23,0.98))",
+  boxShadow: "var(--shadow)",
+}
+
+const eyebrow: React.CSSProperties = {
+  textTransform: "uppercase",
+  letterSpacing: 3,
+  fontWeight: 800,
+  color: "var(--muted)",
+  fontSize: 12,
+  marginBottom: 8,
+}
+
+const title: React.CSSProperties = { fontSize: 36, margin: "4px 0", letterSpacing: -0.6 }
+
+const subtitle: React.CSSProperties = { color: "var(--text-secondary)", marginTop: 6, lineHeight: 1.45 }
+
+const actions: React.CSSProperties = { display: "flex", gap: 16, marginTop: 26, flexWrap: "wrap" }
+
+const cta: React.CSSProperties = {
+  padding: "12px 18px",
+  borderRadius: 14,
+  fontWeight: 800,
+  border: "none",
+  textDecoration: "none",
+  boxShadow: "var(--shadow-sm)",
+  transition: "transform 160ms ease, box-shadow 200ms ease, background 200ms ease",
+}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -1,0 +1,16 @@
+import AppShell from "../../layout/AppShell"
+import { adminNav } from "./nav"
+
+export default function AdminSettings() {
+  return (
+    <AppShell title="Admin settings" subtitle="Prototype controls" navSections={adminNav} chips={["Admin"]}>
+      <div className="cs-card" style={{ padding: 18, display: "grid", gap: 12 }}>
+        <div style={{ fontWeight: 800 }}>Environment</div>
+        <div style={{ color: "var(--text-secondary)" }}>
+          Admin credentials are defined via environment variables <code>VITE_ADMIN_EMAIL</code> and <code>VITE_ADMIN_PASSWORD</code>. Defaults
+          are seeded if none are set.
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/pages/admin/AdminTenantForm.tsx
+++ b/src/pages/admin/AdminTenantForm.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useState } from "react"
+import type { FormEvent } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import AppShell from "../../layout/AppShell"
+import { createTenant, getTenant, updateTenant } from "../../data/tenants"
+import type { Tenant, TenantInput } from "../../data/tenants"
+import { createUser, listUsersByTenant, resetPassword } from "../../data/users"
+import type { User } from "../../data/users"
+import { adminNav } from "./nav"
+
+export default function AdminTenantForm() {
+  const { tenantId } = useParams()
+  const navigate = useNavigate()
+  const editing = Boolean(tenantId)
+
+  const [form, setForm] = useState<Partial<Tenant>>({
+    tenant_code: "",
+    tenant_name: "",
+    legal_name: "",
+    region: "",
+    tenant_type: "",
+    timezone: "",
+    currency: "",
+    subscription: "",
+    status: "Active",
+  })
+  const [primaryEmail, setPrimaryEmail] = useState("")
+  const [primaryPassword, setPrimaryPassword] = useState("")
+  const [resetPasswordValue, setResetPasswordValue] = useState("")
+  const [users, setUsers] = useState<User[]>([])
+
+  useEffect(() => {
+    if (editing && tenantId) {
+      const tenant = getTenant(tenantId)
+      if (tenant) {
+        setForm(tenant)
+        setUsers(listUsersByTenant(tenant.tenant_id))
+      }
+    }
+  }, [editing, tenantId])
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!form.tenant_code || !form.tenant_name) return
+    if (editing && tenantId) {
+      updateTenant(tenantId, form)
+    } else {
+      const newTenant = createTenant(form as TenantInput)
+      navigate(`/admin/tenants/${newTenant.tenant_id}/edit`)
+      return
+    }
+    navigate("/admin/tenants")
+  }
+
+  const primaryUser = useMemo(() => users.find((u) => u.role === "CUSTOMER_PRIMARY"), [users])
+
+  const createPrimary = (e: FormEvent) => {
+    e.preventDefault()
+    if (!tenantId || !primaryEmail || !primaryPassword) return
+    createUser({ tenant_id: tenantId, email: primaryEmail, password: primaryPassword, role: "CUSTOMER_PRIMARY" })
+    setUsers(listUsersByTenant(tenantId))
+    setPrimaryPassword("")
+  }
+
+  const resetPasswordHandler = (e: FormEvent) => {
+    e.preventDefault()
+    if (!primaryUser || !resetPasswordValue) return
+    resetPassword(primaryUser.user_id, resetPasswordValue)
+    setUsers(listUsersByTenant(primaryUser.tenant_id || ""))
+    setResetPasswordValue("")
+  }
+
+  return (
+    <AppShell
+      title={editing ? "Edit tenant" : "Create tenant"}
+      subtitle="Admin controls for onboarding tenants"
+      navSections={adminNav}
+      chips={[editing ? "Tenant" : "Create", "Admin"]}
+    >
+      <form className="cs-card" style={{ padding: 18, display: "grid", gap: 14 }} onSubmit={onSubmit}>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12 }}>
+          {inputField("Tenant name", "tenant_name", form.tenant_name ?? "", setForm)}
+          {inputField("Tenant code", "tenant_code", form.tenant_code ?? "", setForm)}
+          {inputField("Legal name", "legal_name", form.legal_name ?? "", setForm)}
+          {inputField("Type", "tenant_type", form.tenant_type ?? "", setForm)}
+          {inputField("Region", "region", form.region ?? "", setForm)}
+          {inputField("Timezone", "timezone", form.timezone ?? "", setForm)}
+          {inputField("Currency", "currency", form.currency ?? "", setForm)}
+          {inputField("Plan", "subscription", form.subscription ?? "", setForm)}
+        </div>
+
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+          <button className="cs-btn cs-btn-primary" type="submit">
+            {editing ? "Update tenant" : "Create tenant"}
+          </button>
+          <button className="cs-btn" type="button" onClick={() => navigate("/admin/tenants")}>Cancel</button>
+        </div>
+      </form>
+
+      {editing && tenantId ? (
+        <div className="cs-card" style={{ padding: 18, marginTop: 18, display: "grid", gap: 14 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div>
+              <h3 style={{ margin: 0 }}>Primary customer login</h3>
+              <p style={{ margin: 0, color: "var(--text-secondary)" }}>Create or reset the tenant's primary credentials.</p>
+            </div>
+          </div>
+
+          {primaryUser ? (
+            <div style={{ display: "flex", gap: 14, alignItems: "center", flexWrap: "wrap" }}>
+              <div className="cs-pill" style={{ background: "var(--surface)", borderColor: "var(--border)" }}>
+                Primary: {primaryUser.email}
+              </div>
+              <form style={{ display: "flex", gap: 10, alignItems: "center" }} onSubmit={resetPasswordHandler}>
+                <input
+                  className="cs-input"
+                  type="password"
+                  placeholder="New password"
+                  value={resetPasswordValue}
+                  onChange={(e) => setResetPasswordValue(e.target.value)}
+                  style={{ width: 220 }}
+                />
+                <button className="cs-btn" type="submit">
+                  Reset password
+                </button>
+              </form>
+            </div>
+          ) : (
+            <form style={{ display: "grid", gap: 12, maxWidth: 420 }} onSubmit={createPrimary}>
+              <label style={label}>
+                Primary admin email
+                <input className="cs-input" value={primaryEmail} onChange={(e) => setPrimaryEmail(e.target.value)} />
+              </label>
+              <label style={label}>
+                Password
+                <input
+                  className="cs-input"
+                  type="password"
+                  value={primaryPassword}
+                  onChange={(e) => setPrimaryPassword(e.target.value)}
+                />
+              </label>
+              <button className="cs-btn cs-btn-primary" type="submit">
+                Create primary user
+              </button>
+            </form>
+          )}
+        </div>
+      ) : null}
+    </AppShell>
+  )
+}
+
+function inputField(labelText: string, key: keyof Tenant, value: string, setForm: (next: any) => void) {
+  return (
+    <label style={label}>
+      {labelText}
+      <input
+        className="cs-input"
+        value={value}
+        onChange={(e) =>
+          setForm((prev: Partial<Tenant>) => ({
+            ...prev,
+            [key]: e.target.value,
+          }))
+        }
+      />
+    </label>
+  )
+}
+
+const label: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 6, fontWeight: 700, color: "var(--text-secondary)" }

--- a/src/pages/admin/AdminTenants.tsx
+++ b/src/pages/admin/AdminTenants.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react"
+import AppShell from "../../layout/AppShell"
+import { listTenants, setTenantStatus } from "../../data/tenants"
+import type { Tenant, TenantStatus } from "../../data/tenants"
+import { Link } from "react-router-dom"
+import { adminNav } from "./nav"
+
+export default function AdminTenants() {
+  const [tenants, setTenants] = useState<Tenant[]>([])
+
+  useEffect(() => {
+    setTenants(listTenants())
+  }, [])
+
+  const toggleStatus = (tenant: Tenant) => {
+    const nextStatus: TenantStatus = tenant.status === "Active" ? "Inactive" : "Active"
+    const updated = setTenantStatus(tenant.tenant_id, nextStatus)
+    if (updated) {
+      setTenants(listTenants())
+    }
+  }
+
+  return (
+    <AppShell title="Tenants" subtitle="Administer tenant records" navSections={adminNav} chips={["Admin", "CoreSight"]}>
+      <div className="cs-card" style={{ padding: 18 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+          <h3 style={{ margin: 0 }}>All tenants</h3>
+          <Link className="cs-btn cs-btn-primary" to="/admin/tenants/new">
+            + Create Tenant
+          </Link>
+        </div>
+        <div style={{ overflow: "auto" }}>
+          <table className="cs-table">
+            <thead>
+              <tr>
+                <th className="cs-th">Tenant</th>
+                <th className="cs-th">Code</th>
+                <th className="cs-th">Region</th>
+                <th className="cs-th">Status</th>
+                <th className="cs-th">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tenants.map((tenant, idx) => (
+                <tr key={tenant.tenant_id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                  <td className="cs-td">
+                    <div style={{ fontWeight: 800 }}>{tenant.tenant_name}</div>
+                    <div style={{ color: "var(--muted)", fontSize: 12 }}>{tenant.legal_name}</div>
+                  </td>
+                  <td className="cs-td">{tenant.tenant_code}</td>
+                  <td className="cs-td">{tenant.region ?? "-"}</td>
+                  <td className="cs-td">
+                    <span className="cs-pill" style={{ background: "rgba(77,163,255,0.12)", borderColor: "var(--border)" }}>
+                      {tenant.status}
+                    </span>
+                  </td>
+                  <td className="cs-td" style={{ display: "flex", gap: 10 }}>
+                    <Link className="cs-btn" to={`/admin/tenants/${tenant.tenant_id}/edit`}>
+                      View / Edit
+                    </Link>
+                    <button className="cs-btn" onClick={() => toggleStatus(tenant)}>
+                      {tenant.status === "Active" ? "Deactivate" : "Activate"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react"
+import AppShell from "../../layout/AppShell"
+import { listUsers } from "../../data/users"
+import type { User } from "../../data/users"
+import { listTenants } from "../../data/tenants"
+import { adminNav } from "./nav"
+
+export default function AdminUsers() {
+  const [users, setUsers] = useState<User[]>([])
+  const [tenantMap, setTenantMap] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    setUsers(listUsers())
+    const tenants = listTenants()
+    const map: Record<string, string> = {}
+    tenants.forEach((t) => {
+      map[t.tenant_id] = t.tenant_name
+    })
+    setTenantMap(map)
+  }, [])
+
+  return (
+    <AppShell title="Tenant users" subtitle="Accounts issued by admins" navSections={adminNav} chips={["Admin"]}>
+      <div className="cs-card" style={{ padding: 18 }}>
+        <table className="cs-table">
+          <thead>
+            <tr>
+              <th className="cs-th">Email</th>
+              <th className="cs-th">Role</th>
+              <th className="cs-th">Tenant</th>
+              <th className="cs-th">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user, idx) => (
+              <tr key={user.user_id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                <td className="cs-td">{user.email}</td>
+                <td className="cs-td">{user.role}</td>
+                <td className="cs-td">{user.tenant_id ? tenantMap[user.tenant_id] ?? user.tenant_id : "Admin"}</td>
+                <td className="cs-td">{user.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/pages/admin/nav.ts
+++ b/src/pages/admin/nav.ts
@@ -1,0 +1,13 @@
+import type { NavSection } from "../../layout/AppShell"
+
+export const adminNav: NavSection[] = [
+  {
+    label: "Admin",
+    items: [
+      { to: "/admin/tenants", label: "Tenants", icon: "🏢" },
+      { to: "/admin/tenants/new", label: "Create Tenant", icon: "＋" },
+      { to: "/admin/users", label: "Users", icon: "👥" },
+      { to: "/admin/settings", label: "Settings", icon: "⚙" },
+    ],
+  },
+]

--- a/src/pages/customer/AIInsights.tsx
+++ b/src/pages/customer/AIInsights.tsx
@@ -1,0 +1,11 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+export default function CustomerAIInsights() {
+  return (
+    <CustomerPageShell title="AI Insights" subtitle="Reserved for upcoming AI copilots">
+      <div className="cs-card" style={{ padding: 18 }}>
+        <p style={{ color: "var(--text-secondary)", margin: 0 }}>Coming soon — AI guided recommendations and anomaly detection.</p>
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/Analytics.tsx
+++ b/src/pages/customer/Analytics.tsx
@@ -1,0 +1,11 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+export default function CustomerAnalytics() {
+  return (
+    <CustomerPageShell title="Analytics" subtitle="Signals and KPIs in progress">
+      <div className="cs-card" style={{ padding: 18 }}>
+        <p style={{ color: "var(--text-secondary)", margin: 0 }}>Analytics widgets will land here. The structure already follows the portal shell.</p>
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/CustomerPageShell.tsx
+++ b/src/pages/customer/CustomerPageShell.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react"
+import AppShell from "../../layout/AppShell"
+import { customerNav } from "./nav"
+import { useCustomerAuth } from "../../auth/CustomerAuthContext"
+
+export default function CustomerPageShell({ title, subtitle, children }: { title: string; subtitle?: string; children: ReactNode }) {
+  const { tenant, user } = useCustomerAuth()
+  const chips = [tenant ? tenant.tenant_name : "Tenant", tenant?.region ?? ""]
+  const enrichedChips = user ? [...chips, user.email] : chips
+
+  return (
+    <AppShell title={title} subtitle={subtitle} navSections={customerNav} chips={enrichedChips.filter(Boolean)}>
+      {children}
+    </AppShell>
+  )
+}

--- a/src/pages/customer/Dashboard.tsx
+++ b/src/pages/customer/Dashboard.tsx
@@ -1,0 +1,16 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+export default function CustomerDashboard() {
+  return (
+    <CustomerPageShell title="Dashboard" subtitle="Executive overview for your tenant">
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 14 }}>
+        {["Usage", "Spend", "Signals", "Health"].map((card) => (
+          <div key={card} className="cs-card" style={{ padding: 16 }}>
+            <div style={{ fontWeight: 800, marginBottom: 8 }}>{card}</div>
+            <div style={{ color: "var(--text-secondary)" }}>Placeholder KPI card — data wiring comes later.</div>
+          </div>
+        ))}
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/Departments.tsx
+++ b/src/pages/customer/Departments.tsx
@@ -1,0 +1,32 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+export default function CustomerDepartments() {
+  const departments = [
+    { name: "Engineering", owner: "Priya" },
+    { name: "Finance", owner: "Amir" },
+    { name: "Operations", owner: "Lina" },
+  ]
+
+  return (
+    <CustomerPageShell title="Departments" subtitle="Department level controls and visibility">
+      <div className="cs-card" style={{ padding: 18 }}>
+        <table className="cs-table">
+          <thead>
+            <tr>
+              <th className="cs-th">Name</th>
+              <th className="cs-th">Owner</th>
+            </tr>
+          </thead>
+          <tbody>
+            {departments.map((dept, idx) => (
+              <tr key={dept.name} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                <td className="cs-td">{dept.name}</td>
+                <td className="cs-td">{dept.owner}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/Reports.tsx
+++ b/src/pages/customer/Reports.tsx
@@ -1,0 +1,32 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+export default function CustomerReports() {
+  const rows = [
+    { name: "Executive overview", status: "Ready" },
+    { name: "Spend by department", status: "Ready" },
+    { name: "Renewals heatmap", status: "Coming soon" },
+  ]
+
+  return (
+    <CustomerPageShell title="Reports" subtitle="Enterprise-grade reports in dark mode">
+      <div className="cs-card" style={{ padding: 18 }}>
+        <table className="cs-table">
+          <thead>
+            <tr>
+              <th className="cs-th">Report</th>
+              <th className="cs-th">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={row.name} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                <td className="cs-td">{row.name}</td>
+                <td className="cs-td">{row.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/Settings.tsx
+++ b/src/pages/customer/Settings.tsx
@@ -1,0 +1,36 @@
+import CustomerPageShell from "./CustomerPageShell"
+import { useCustomerAuth } from "../../auth/CustomerAuthContext"
+
+export default function CustomerSettings() {
+  const { tenant } = useCustomerAuth()
+
+  return (
+    <CustomerPageShell title="Settings" subtitle="Tenant context">
+      <div className="cs-card" style={{ padding: 18, display: "grid", gap: 10 }}>
+        {tenant ? (
+          <>
+            {infoRow("Tenant", tenant.tenant_name)}
+            {infoRow("Code", tenant.tenant_code)}
+            {infoRow("Legal name", tenant.legal_name ?? "–")}
+            {infoRow("Region", tenant.region ?? "–")}
+            {infoRow("Timezone", tenant.timezone ?? "–")}
+            {infoRow("Currency", tenant.currency ?? "–")}
+            {infoRow("Plan", tenant.subscription ?? "–")}
+            {infoRow("Status", tenant.status)}
+          </>
+        ) : (
+          <div style={{ color: "var(--text-secondary)" }}>No tenant selected.</div>
+        )}
+      </div>
+    </CustomerPageShell>
+  )
+}
+
+function infoRow(label: string, value: string) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", borderBottom: "1px solid var(--border)", paddingBottom: 10 }}>
+      <div style={{ color: "var(--text-secondary)", fontWeight: 700 }}>{label}</div>
+      <div style={{ fontWeight: 800 }}>{value}</div>
+    </div>
+  )
+}

--- a/src/pages/customer/nav.ts
+++ b/src/pages/customer/nav.ts
@@ -1,0 +1,15 @@
+import type { NavSection } from "../../layout/AppShell"
+
+export const customerNav: NavSection[] = [
+  {
+    label: "Portal",
+    items: [
+      { to: "/app/dashboard", label: "Dashboard", icon: "📊" },
+      { to: "/app/reports", label: "Reports", icon: "🗒" },
+      { to: "/app/departments", label: "Departments", icon: "🏢" },
+      { to: "/app/analytics", label: "Analytics", icon: "📈" },
+      { to: "/app/ai-insights", label: "AI Insights", icon: "✨" },
+      { to: "/app/settings", label: "Settings", icon: "⚙" },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- add landing and login flows for admin and customer entry backed by localStorage-based auth contexts
- build admin portal for tenant lifecycle management and customer credential creation/reset
- provide customer portal shell with dashboard, reports, departments, analytics, AI insights, and settings placeholders

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695675ff23e08328a82398b81b99e433)