### PR TITLE
Restore sheet tenant onboarding and expand customer portal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,15 @@ import AdminTenants from "./pages/admin/AdminTenants"
 import AdminTenantForm from "./pages/admin/AdminTenantForm"
 import AdminUsers from "./pages/admin/AdminUsers"
 import AdminSettings from "./pages/admin/AdminSettings"
+import VendorNew from "./pages/admin/VendorNew"
 import CustomerDashboard from "./pages/customer/Dashboard"
 import CustomerReports from "./pages/customer/Reports"
 import CustomerDepartments from "./pages/customer/Departments"
 import CustomerAnalytics from "./pages/customer/Analytics"
 import CustomerAIInsights from "./pages/customer/AIInsights"
 import CustomerSettings from "./pages/customer/Settings"
+import CustomerSubscriptions from "./pages/customer/Subscriptions"
+import CustomerRenewals from "./pages/customer/Renewals"
 import { useAdminAuth } from "./auth/AdminAuthContext"
 import { useCustomerAuth } from "./auth/CustomerAuthContext"
 
@@ -48,7 +51,7 @@ export default function App() {
           path="/admin/tenants/new"
           element={
             <AdminGuard>
-              <AdminTenantForm />
+              <VendorNew />
             </AdminGuard>
           }
         />
@@ -84,6 +87,22 @@ export default function App() {
           element={
             <CustomerGuard>
               <CustomerDashboard />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/subscriptions"
+          element={
+            <CustomerGuard>
+              <CustomerSubscriptions />
+            </CustomerGuard>
+          }
+        />
+        <Route
+          path="/app/renewals"
+          element={
+            <CustomerGuard>
+              <CustomerRenewals />
             </CustomerGuard>
           }
         />

--- a/src/data/tenants.ts
+++ b/src/data/tenants.ts
@@ -12,6 +12,8 @@ export type Tenant = {
   timezone?: string
   currency?: string
   subscription?: string
+  primary_admin_name?: string
+  primary_admin_email?: string
   status: TenantStatus
   created_at: string
   updated_at: string
@@ -51,6 +53,8 @@ export function createTenant(payload: TenantInput): Tenant {
     timezone: payload.timezone ?? "UTC",
     currency: payload.currency ?? "USD",
     subscription: payload.subscription ?? "Enterprise",
+    primary_admin_email: payload.primary_admin_email,
+    primary_admin_name: payload.primary_admin_name,
     status: payload.status ?? "Active",
     created_at: now,
     updated_at: now,
@@ -94,4 +98,68 @@ export function ensureSeedTenant() {
     subscription: "Pilot",
     status: "Active",
   })
+}
+
+export type TenantSheetPayload = {
+  tenant_id: string
+  tenant_code: string
+  tenant_name: string
+  legal_name?: string
+  tenant_type?: string
+  primary_country?: string
+  primary_timezone?: string
+  default_currency?: string
+  plan_type?: string
+  subscription_status?: string
+  tenant_status?: string
+  is_demo_tenant?: boolean
+  data_retention_policy?: string
+  compliance_flag?: boolean
+  primary_admin_name?: string
+  primary_admin_email?: string
+  created_by_user_id?: string
+  ai_insights_enabled?: boolean
+  cost_optimization_enabled?: boolean
+  usage_analytics_enabled?: boolean
+  created_at?: string
+  updated_at?: string
+  last_active_at?: string
+  primary_admin_user_id?: string
+  notes?: string
+  vat_registration_number?: string
+  national_address?: string
+}
+
+export function upsertTenantMirrorFromSheet(payload: TenantSheetPayload) {
+  const now = nowIso()
+  const status: TenantStatus = payload.tenant_status === "Active" ? "Active" : "Inactive"
+
+  const nextTenant: Tenant = {
+    tenant_id: payload.tenant_id,
+    tenant_code: payload.tenant_code,
+    tenant_name: payload.tenant_name,
+    legal_name: payload.legal_name ?? payload.tenant_name,
+    tenant_type: payload.tenant_type ?? "Enterprise",
+    region: payload.primary_country ?? "Global",
+    timezone: payload.primary_timezone ?? "UTC",
+    currency: payload.default_currency ?? "USD",
+    subscription: payload.plan_type ?? "",
+    primary_admin_email: payload.primary_admin_email,
+    primary_admin_name: payload.primary_admin_name,
+    status,
+    created_at: payload.created_at || now,
+    updated_at: payload.updated_at || now,
+  }
+
+  const existing = listTenants()
+  const matchIndex = existing.findIndex((t) => t.tenant_id === nextTenant.tenant_id)
+  if (matchIndex >= 0) {
+    existing[matchIndex] = { ...existing[matchIndex], ...nextTenant, updated_at: nowIso() }
+    persistTenants([...existing])
+    return existing[matchIndex]
+  }
+
+  const next = [...existing, nextTenant]
+  persistTenants(next)
+  return nextTenant
 }

--- a/src/layout/AppShell.tsx
+++ b/src/layout/AppShell.tsx
@@ -1,7 +1,9 @@
 // src/layout/AppShell.tsx
-import { NavLink } from "react-router-dom"
+import { NavLink, useNavigate } from "react-router-dom"
 import { useMemo, useState } from "react"
 import type { ReactNode, CSSProperties } from "react"
+import { useAdminAuth } from "../auth/AdminAuthContext"
+import { useCustomerAuth } from "../auth/CustomerAuthContext"
 
 export type NavSection = {
   label?: string
@@ -20,6 +22,9 @@ export type AppShellProps = {
 export default function AppShell({ title, subtitle, actions, children, navSections, chips }: AppShellProps) {
   const [isPinned, setIsPinned] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
+  const navigate = useNavigate()
+  const adminAuth = useAdminAuth()
+  const customerAuth = useCustomerAuth()
 
   const navItems = useMemo(() => navSections ?? defaultNav, [navSections])
 
@@ -103,6 +108,19 @@ export default function AppShell({ title, subtitle, actions, children, navSectio
                 {chipNode}
               </span>
             ))}
+            {(adminAuth.isAuthenticated || customerAuth.isAuthenticated) && (
+              <button
+                className="cs-btn"
+                style={{ height: 38, marginLeft: 8 }}
+                onClick={() => {
+                  if (adminAuth.isAuthenticated) adminAuth.logout()
+                  if (customerAuth.isAuthenticated) customerAuth.logout()
+                  navigate("/")
+                }}
+              >
+                Logout
+              </button>
+            )}
           </div>
         </div>
 

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import type { FormEvent } from "react"
-import { Navigate, useNavigate } from "react-router-dom"
+import { Link, Navigate, useNavigate } from "react-router-dom"
 import { useAdminAuth } from "../auth/AdminAuthContext"
 
 export default function AdminLogin() {
@@ -25,6 +25,14 @@ export default function AdminLogin() {
   return (
     <div style={wrap}>
       <div style={card}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+          <Link to="/" style={backLink}>
+            ← Back to login selection
+          </Link>
+          <Link to="/customer/login" style={{ ...switchLink }}>
+            Go to Customer Login
+          </Link>
+        </div>
         <p style={eyebrow}>Admin access</p>
         <h2 style={title}>Administrator login</h2>
         <p style={subtitle}>Use the prototype admin credentials. Update env vars to change.</p>
@@ -48,6 +56,11 @@ export default function AdminLogin() {
           <button className="cs-btn cs-btn-primary" type="submit">
             Login as Admin
           </button>
+          <div style={{ textAlign: "right" }}>
+            <Link to="/customer/login" style={{ ...switchLink, fontSize: 12 }}>
+              Switch to Customer Login
+            </Link>
+          </div>
         </form>
       </div>
     </div>
@@ -85,4 +98,16 @@ const errorBox: React.CSSProperties = {
   padding: 10,
   color: "#ffb4b4",
   fontWeight: 700,
+}
+const backLink: React.CSSProperties = {
+  color: "var(--text-secondary)",
+  textDecoration: "none",
+  fontWeight: 700,
+  fontSize: 13,
+}
+
+const switchLink: React.CSSProperties = {
+  color: "var(--muted)",
+  fontWeight: 700,
+  fontSize: 13,
 }

--- a/src/pages/CustomerLogin.tsx
+++ b/src/pages/CustomerLogin.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import type { FormEvent } from "react"
-import { Navigate, useNavigate } from "react-router-dom"
+import { Link, Navigate, useNavigate } from "react-router-dom"
 import { useCustomerAuth, seedDemoUsers } from "../auth/CustomerAuthContext"
 import { ensureSeedTenant } from "../data/tenants"
 
@@ -32,6 +32,14 @@ export default function CustomerLogin() {
   return (
     <div style={wrap}>
       <div style={card}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+          <Link to="/" style={backLink}>
+            ← Back to login selection
+          </Link>
+          <Link to="/admin/login" style={switchLink}>
+            Go to Admin Login
+          </Link>
+        </div>
         <p style={eyebrow}>Customer access</p>
         <h2 style={title}>Tenant login</h2>
         <p style={subtitle}>Enter the tenant code and credentials issued by your CoreSight admin.</p>
@@ -59,6 +67,11 @@ export default function CustomerLogin() {
           <button className="cs-btn cs-btn-primary" type="submit">
             Login to portal
           </button>
+          <div style={{ textAlign: "right" }}>
+            <Link to="/admin/login" style={{ ...switchLink, fontSize: 12 }}>
+              Switch to Admin Login
+            </Link>
+          </div>
         </form>
       </div>
     </div>
@@ -96,4 +109,16 @@ const errorBox: React.CSSProperties = {
   padding: 10,
   color: "#ffb4b4",
   fontWeight: 700,
+}
+const backLink: React.CSSProperties = {
+  color: "var(--text-secondary)",
+  textDecoration: "none",
+  fontWeight: 700,
+  fontSize: 13,
+}
+
+const switchLink: React.CSSProperties = {
+  color: "var(--muted)",
+  fontWeight: 700,
+  fontSize: 13,
 }

--- a/src/pages/admin/AdminTenantForm.tsx
+++ b/src/pages/admin/AdminTenantForm.tsx
@@ -22,6 +22,8 @@ export default function AdminTenantForm() {
     timezone: "",
     currency: "",
     subscription: "",
+    primary_admin_email: "",
+    primary_admin_name: "",
     status: "Active",
   })
   const [primaryEmail, setPrimaryEmail] = useState("")
@@ -73,7 +75,11 @@ export default function AdminTenantForm() {
   return (
     <AppShell
       title={editing ? "Edit tenant" : "Create tenant"}
-      subtitle="Admin controls for onboarding tenants"
+      subtitle={
+        editing
+          ? "Local mirror edit (does not auto-sync Google Sheet)"
+          : "Admin controls for onboarding tenants"
+      }
       navSections={adminNav}
       chips={[editing ? "Tenant" : "Create", "Admin"]}
     >
@@ -87,6 +93,8 @@ export default function AdminTenantForm() {
           {inputField("Timezone", "timezone", form.timezone ?? "", setForm)}
           {inputField("Currency", "currency", form.currency ?? "", setForm)}
           {inputField("Plan", "subscription", form.subscription ?? "", setForm)}
+          {inputField("Primary admin name", "primary_admin_name", form.primary_admin_name ?? "", setForm)}
+          {inputField("Primary admin email", "primary_admin_email", form.primary_admin_email ?? "", setForm)}
         </div>
 
         <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>

--- a/src/pages/admin/VendorNew.tsx
+++ b/src/pages/admin/VendorNew.tsx
@@ -8,6 +8,7 @@ import {
   SUBSCRIPTION_STATUS_OPTIONS,
   makeTenantId,
 } from "../../data/vendors"
+import { upsertTenantMirrorFromSheet } from "../../data/tenants"
 
 const SHEET_URL =
   "https://script.google.com/macros/s/AKfycbwxTAPJITLdR3AUQoseEs-TsUefbWfuPPmt2rrqsmgDBGXSfAL3xDeUG10VLKUrGhDb0w/exec"
@@ -158,6 +159,8 @@ export default function VendorNew() {
       if (!json?.ok) {
         throw new Error(json?.error || "Create failed")
       }
+
+      upsertTenantMirrorFromSheet(payload)
 
       setSuccess("✅ Tenant created and appended to Google Sheet.")
       setStep(1)

--- a/src/pages/customer/Renewals.tsx
+++ b/src/pages/customer/Renewals.tsx
@@ -1,0 +1,74 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+const renewals = [
+  {
+    subscription: "Enterprise",
+    date: "2024-11-15",
+    term: "12 months",
+    status: "On track",
+    owner: "Procurement",
+    notes: "Awaiting approval",
+  },
+  {
+    subscription: "AI Insights Add-on",
+    date: "2024-07-20",
+    term: "12 months",
+    status: "Pending",
+    owner: "IT Ops",
+    notes: "Needs usage review",
+  },
+]
+
+export default function CustomerRenewals() {
+  return (
+    <CustomerPageShell
+      title="Renewals"
+      subtitle="Key renewal dates and owners"
+    >
+      <div className="cs-card" style={{ padding: 18, display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h3 style={{ margin: 0 }}>Upcoming renewals</h3>
+            <p style={{ margin: 0, color: "var(--text-secondary)" }}>
+              Track renewal readiness and assign owners.
+            </p>
+          </div>
+          <button className="cs-btn cs-btn-primary">Initiate Renewal</button>
+        </div>
+
+        <table className="cs-table">
+          <thead>
+            <tr>
+              <th className="cs-th">Subscription</th>
+              <th className="cs-th">Renewal Date</th>
+              <th className="cs-th">Term</th>
+              <th className="cs-th">Status</th>
+              <th className="cs-th">Owner</th>
+              <th className="cs-th">Notes</th>
+              <th className="cs-th">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {renewals.map((row, idx) => (
+              <tr key={`${row.subscription}-${row.date}`} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                <td className="cs-td">{row.subscription}</td>
+                <td className="cs-td">{row.date}</td>
+                <td className="cs-td">{row.term}</td>
+                <td className="cs-td">
+                  <span className="cs-pill" style={{ padding: "6px 10px", background: "var(--surface-elevated)" }}>
+                    {row.status}
+                  </span>
+                </td>
+                <td className="cs-td">{row.owner}</td>
+                <td className="cs-td">{row.notes}</td>
+                <td className="cs-td">
+                  <button className="cs-btn" style={{ height: 36 }}>Details</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/Subscriptions.tsx
+++ b/src/pages/customer/Subscriptions.tsx
@@ -1,0 +1,74 @@
+import CustomerPageShell from "./CustomerPageShell"
+
+const rows = [
+  {
+    plan: "Enterprise",
+    status: "Active",
+    start: "2024-01-01",
+    end: "2024-12-31",
+    seats: 120,
+    renewal: "Annual",
+  },
+  {
+    plan: "AI Insights Add-on",
+    status: "Inactive",
+    start: "2023-08-01",
+    end: "2024-07-31",
+    seats: 30,
+    renewal: "Annual",
+  },
+]
+
+export default function CustomerSubscriptions() {
+  return (
+    <CustomerPageShell
+      title="Subscriptions"
+      subtitle="Current entitlements, terms, and upgrade controls"
+    >
+      <div className="cs-card" style={{ padding: 18, display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h3 style={{ margin: 0 }}>Active subscriptions</h3>
+            <p style={{ margin: 0, color: "var(--text-secondary)" }}>
+              Boardroom-ready view of your plans and renewal posture.
+            </p>
+          </div>
+          <button className="cs-btn cs-btn-primary">Request Upgrade</button>
+        </div>
+
+        <table className="cs-table">
+          <thead>
+            <tr>
+              <th className="cs-th">Plan</th>
+              <th className="cs-th">Status</th>
+              <th className="cs-th">Start Date</th>
+              <th className="cs-th">End Date</th>
+              <th className="cs-th">Seats</th>
+              <th className="cs-th">Renewal Type</th>
+              <th className="cs-th">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={row.plan} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                <td className="cs-td">{row.plan}</td>
+                <td className="cs-td">
+                  <span className="cs-pill" style={{ padding: "6px 10px", background: "var(--surface-elevated)" }}>
+                    {row.status}
+                  </span>
+                </td>
+                <td className="cs-td">{row.start}</td>
+                <td className="cs-td">{row.end}</td>
+                <td className="cs-td">{row.seats}</td>
+                <td className="cs-td">{row.renewal}</td>
+                <td className="cs-td">
+                  <button className="cs-btn" style={{ height: 36 }}>Manage</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CustomerPageShell>
+  )
+}

--- a/src/pages/customer/nav.ts
+++ b/src/pages/customer/nav.ts
@@ -5,6 +5,8 @@ export const customerNav: NavSection[] = [
     label: "Portal",
     items: [
       { to: "/app/dashboard", label: "Dashboard", icon: "📊" },
+      { to: "/app/subscriptions", label: "Subscriptions", icon: "🧾" },
+      { to: "/app/renewals", label: "Renewals", icon: "♻️" },
       { to: "/app/reports", label: "Reports", icon: "🗒" },
       { to: "/app/departments", label: "Departments", icon: "🏢" },
       { to: "/app/analytics", label: "Analytics", icon: "📈" },


### PR DESCRIPTION
## Summary
- Route admin tenant creation through the original Google Sheets-backed onboarding wizard and mirror successful rows locally
- Enhance login flows with clear navigation back to login selection and cross-links between admin and customer logins
- Expand the customer portal navigation with Subscriptions and Renewals placeholders while keeping dark theme and logout controls

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695678e635c48328bce4545cfad9af50)