### PR TITLE
Wire tenants sheet sync and tenant-scoped customer data

### DIFF
--- a/src/data/tenantRecords.ts
+++ b/src/data/tenantRecords.ts
@@ -1,0 +1,129 @@
+// src/data/tenantRecords.ts
+import { generateId, readStorage, writeStorage } from "../lib/storage"
+import type { Tenant } from "./tenants"
+
+export type SubscriptionRecord = {
+  id: string
+  tenant_id: string
+  plan: string
+  status: string
+  start_date?: string
+  end_date?: string
+  seats?: number
+  renewal_type?: string
+  amount?: number
+  currency?: string
+}
+
+export type RenewalRecord = {
+  id: string
+  tenant_id: string
+  subscription: string
+  renewal_date: string
+  term: string
+  status: string
+  owner?: string
+  notes?: string
+}
+
+const SUB_KEY = "coresight_subscription_records"
+const RENEWAL_KEY = "coresight_renewal_records"
+
+function persistSubscriptions(next: SubscriptionRecord[]) {
+  writeStorage(SUB_KEY, next)
+}
+
+function persistRenewals(next: RenewalRecord[]) {
+  writeStorage(RENEWAL_KEY, next)
+}
+
+export function listSubscriptions(): SubscriptionRecord[] {
+  return readStorage<SubscriptionRecord[]>(SUB_KEY, [])
+}
+
+export function listRenewals(): RenewalRecord[] {
+  return readStorage<RenewalRecord[]>(RENEWAL_KEY, [])
+}
+
+export function listSubscriptionsByTenant(tenantId: string) {
+  return listSubscriptions().filter((s) => s.tenant_id === tenantId)
+}
+
+export function listRenewalsByTenant(tenantId: string) {
+  return listRenewals().filter((r) => r.tenant_id === tenantId)
+}
+
+export function upsertSubscription(record: SubscriptionRecord) {
+  const existing = listSubscriptions()
+  const idx = existing.findIndex((s) => s.id === record.id)
+  if (idx >= 0) {
+    existing[idx] = { ...existing[idx], ...record }
+    persistSubscriptions([...existing])
+    return existing[idx]
+  }
+  const created = { ...record, id: record.id || generateId("sub") }
+  persistSubscriptions([...existing, created])
+  return created
+}
+
+export function upsertRenewal(record: RenewalRecord) {
+  const existing = listRenewals()
+  const idx = existing.findIndex((r) => r.id === record.id)
+  if (idx >= 0) {
+    existing[idx] = { ...existing[idx], ...record }
+    persistRenewals([...existing])
+    return existing[idx]
+  }
+  const created = { ...record, id: record.id || generateId("renewal") }
+  persistRenewals([...existing, created])
+  return created
+}
+
+function addMonths(date: Date, months: number) {
+  const d = new Date(date)
+  d.setMonth(d.getMonth() + months)
+  return d
+}
+
+function formatDate(date: Date) {
+  return date.toISOString().slice(0, 10)
+}
+
+export function ensureTenantLifecycleRecords(tenant: Tenant) {
+  const tenantId = tenant.tenant_id
+  if (!tenantId) return
+
+  const hasSubscription = listSubscriptionsByTenant(tenantId).length > 0
+  const planName = tenant.plan_type || tenant.subscription || "Enterprise"
+  const startDate = tenant.subscription_start_date || formatDate(new Date())
+  const endDate =
+    tenant.subscription_end_date ||
+    formatDate(addMonths(new Date(startDate || Date.now()), 12))
+
+  if (!hasSubscription) {
+    upsertSubscription({
+      id: generateId("sub"),
+      tenant_id: tenantId,
+      plan: planName,
+      status: tenant.subscription_status || "Active",
+      start_date: startDate,
+      end_date: endDate,
+      seats: tenant.max_users,
+      renewal_type: "Annual",
+    })
+  }
+
+  const hasRenewal = listRenewalsByTenant(tenantId).length > 0
+  if (!hasRenewal) {
+    upsertRenewal({
+      id: generateId("renewal"),
+      tenant_id: tenantId,
+      subscription: planName,
+      renewal_date: endDate,
+      term: "12 months",
+      status: tenant.subscription_status || "On track",
+      owner: tenant.primary_admin_name || "Procurement",
+      notes: tenant.primary_admin_email || "Renewal owner notified",
+    })
+  }
+}

--- a/src/data/tenants.ts
+++ b/src/data/tenants.ts
@@ -1,5 +1,6 @@
 // src/data/tenants.ts
 import { generateId, nowIso, readStorage, writeStorage } from "../lib/storage"
+import { appsScriptBaseUrl } from "./api"
 
 export type TenantStatus = "Active" | "Inactive"
 export type Tenant = {
@@ -12,6 +13,12 @@ export type Tenant = {
   timezone?: string
   currency?: string
   subscription?: string
+  plan_type?: string
+  subscription_status?: string
+  subscription_start_date?: string
+  subscription_end_date?: string
+  max_users?: number
+  max_organizations?: number
   primary_admin_name?: string
   primary_admin_email?: string
   status: TenantStatus
@@ -30,7 +37,10 @@ function persistTenants(next: Tenant[]) {
 }
 
 export function getTenant(id: string) {
-  return listTenants().find((t) => t.tenant_id === id)
+  const normalizedId = id?.toLowerCase()
+  return listTenants().find(
+    (t) => t.tenant_id.toLowerCase() === normalizedId || t.tenant_code.toLowerCase() === normalizedId,
+  )
 }
 
 export function getTenantByCode(code: string) {
@@ -53,6 +63,12 @@ export function createTenant(payload: TenantInput): Tenant {
     timezone: payload.timezone ?? "UTC",
     currency: payload.currency ?? "USD",
     subscription: payload.subscription ?? "Enterprise",
+    plan_type: payload.plan_type,
+    subscription_status: payload.subscription_status,
+    subscription_start_date: payload.subscription_start_date,
+    subscription_end_date: payload.subscription_end_date,
+    max_users: payload.max_users,
+    max_organizations: payload.max_organizations,
     primary_admin_email: payload.primary_admin_email,
     primary_admin_name: payload.primary_admin_name,
     status: payload.status ?? "Active",
@@ -100,6 +116,74 @@ export function ensureSeedTenant() {
   })
 }
 
+function normalizeSheetRow(row: Record<string, any>): TenantSheetPayload {
+  return {
+    tenant_id: row.tenant_id || row.tenant_code || "",
+    tenant_code: row.tenant_code || row.code || "",
+    tenant_name: row.tenant_name || row.name || "",
+    legal_name: row.legal_name || row.tenant_name || "",
+    tenant_type: row.tenant_type || row.type || "",
+    primary_country: row.primary_country || row.country || "",
+    primary_timezone: row.primary_timezone || row.timezone || "",
+    default_currency: row.default_currency || row.currency || "",
+    plan_type: row.plan_type || row.subscription || "",
+    subscription_status: row.subscription_status || row.status || "",
+    subscription_start_date: row.subscription_start_date || "",
+    subscription_end_date: row.subscription_end_date || "",
+    max_users: row.max_users,
+    max_organizations: row.max_organizations,
+    tenant_status: row.tenant_status || row.status || "",
+    is_demo_tenant: row.is_demo_tenant,
+    data_retention_policy: row.data_retention_policy,
+    compliance_flag: row.compliance_flag,
+    primary_admin_name: row.primary_admin_name,
+    primary_admin_email: row.primary_admin_email,
+    created_by_user_id: row.created_by_user_id,
+    ai_insights_enabled: row.ai_insights_enabled,
+    cost_optimization_enabled: row.cost_optimization_enabled,
+    usage_analytics_enabled: row.usage_analytics_enabled,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    last_active_at: row.last_active_at,
+    primary_admin_user_id: row.primary_admin_user_id,
+    notes: row.notes,
+    vat_registration_number: row.vat_registration_number,
+    national_address: row.national_address,
+  }
+}
+
+export async function fetchTenantsFromSheet(): Promise<Tenant[]> {
+  const url = new URL(appsScriptBaseUrl)
+  url.searchParams.set("t", `${Date.now()}`)
+
+  const res = await fetch(url.toString())
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`)
+  }
+  const body = await res.json().catch(() => null)
+  const rows: Record<string, any>[] = Array.isArray(body)
+    ? body
+    : body && typeof body === "object" && "data" in body
+      ? ((body as { data?: unknown }).data as Record<string, any>[] | undefined) ?? []
+      : []
+
+  if (!Array.isArray(rows)) {
+    throw new Error("Unexpected sheet response")
+  }
+
+  const normalized = rows
+    .map((row) => normalizeSheetRow(row))
+    .filter((row) => row.tenant_code && row.tenant_name)
+
+  const tenants: Tenant[] = []
+  normalized.forEach((row) => {
+    const t = upsertTenantMirrorFromSheet(row)
+    if (t) tenants.push(t)
+  })
+
+  return tenants
+}
+
 export type TenantSheetPayload = {
   tenant_id: string
   tenant_code: string
@@ -111,6 +195,10 @@ export type TenantSheetPayload = {
   default_currency?: string
   plan_type?: string
   subscription_status?: string
+  subscription_start_date?: string
+  subscription_end_date?: string
+  max_users?: number | string
+  max_organizations?: number | string
   tenant_status?: string
   is_demo_tenant?: boolean
   data_retention_policy?: string
@@ -130,12 +218,21 @@ export type TenantSheetPayload = {
   national_address?: string
 }
 
+function normalizeNumber(value?: number | string) {
+  if (value === undefined || value === null) return undefined
+  const num = typeof value === "string" ? Number(value) : value
+  return Number.isFinite(num) ? Number(num) : undefined
+}
+
 export function upsertTenantMirrorFromSheet(payload: TenantSheetPayload) {
   const now = nowIso()
   const status: TenantStatus = payload.tenant_status === "Active" ? "Active" : "Inactive"
 
+  const id = payload.tenant_id || payload.tenant_code
+  if (!id) throw new Error("Tenant payload missing identifiers")
+
   const nextTenant: Tenant = {
-    tenant_id: payload.tenant_id,
+    tenant_id: id,
     tenant_code: payload.tenant_code,
     tenant_name: payload.tenant_name,
     legal_name: payload.legal_name ?? payload.tenant_name,
@@ -144,6 +241,12 @@ export function upsertTenantMirrorFromSheet(payload: TenantSheetPayload) {
     timezone: payload.primary_timezone ?? "UTC",
     currency: payload.default_currency ?? "USD",
     subscription: payload.plan_type ?? "",
+    plan_type: payload.plan_type ?? "",
+    subscription_status: payload.subscription_status ?? "",
+    subscription_start_date: payload.subscription_start_date,
+    subscription_end_date: payload.subscription_end_date,
+    max_users: normalizeNumber(payload.max_users),
+    max_organizations: normalizeNumber(payload.max_organizations),
     primary_admin_email: payload.primary_admin_email,
     primary_admin_name: payload.primary_admin_name,
     status,
@@ -152,7 +255,9 @@ export function upsertTenantMirrorFromSheet(payload: TenantSheetPayload) {
   }
 
   const existing = listTenants()
-  const matchIndex = existing.findIndex((t) => t.tenant_id === nextTenant.tenant_id)
+  const matchIndex = existing.findIndex(
+    (t) => t.tenant_id === nextTenant.tenant_id || t.tenant_code === nextTenant.tenant_code,
+  )
   if (matchIndex >= 0) {
     existing[matchIndex] = { ...existing[matchIndex], ...nextTenant, updated_at: nowIso() }
     persistTenants([...existing])

--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -12,6 +12,7 @@ export type User = {
   password_hash: string
   role: UserRole
   status: UserStatus
+  name?: string
   created_at: string
   updated_at: string
 }
@@ -61,6 +62,7 @@ export type CreateUserPayload = {
   password: string
   role: UserRole
   status?: UserStatus
+  name?: string
 }
 
 export function createUser(payload: CreateUserPayload): User {
@@ -72,6 +74,7 @@ export function createUser(payload: CreateUserPayload): User {
     password_hash: hashPassword(payload.password),
     role: payload.role,
     status: payload.status ?? "Active",
+    name: payload.name,
     created_at: now,
     updated_at: now,
   }

--- a/src/pages/CustomerLogin.tsx
+++ b/src/pages/CustomerLogin.tsx
@@ -19,9 +19,9 @@ export default function CustomerLogin() {
 
   if (isAuthenticated) return <Navigate to="/app/dashboard" replace />
 
-  const onSubmit = (e: FormEvent) => {
+  const onSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    const result = login(tenantCode, email, password)
+    const result = await login(tenantCode, email, password)
     if (!result.success) {
       setError(result.error)
       return

--- a/src/pages/admin/AdminTenants.tsx
+++ b/src/pages/admin/AdminTenants.tsx
@@ -1,16 +1,46 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import AppShell from "../../layout/AppShell"
-import { listTenants, setTenantStatus } from "../../data/tenants"
+import { fetchTenantsFromSheet, listTenants, setTenantStatus } from "../../data/tenants"
 import type { Tenant, TenantStatus } from "../../data/tenants"
 import { Link } from "react-router-dom"
 import { adminNav } from "./nav"
 
 export default function AdminTenants() {
   const [tenants, setTenants] = useState<Tenant[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const [query, setQuery] = useState("")
+  const [usingMirror, setUsingMirror] = useState(false)
+
+  const load = async () => {
+    setLoading(true)
+    setError(undefined)
+    setUsingMirror(false)
+    try {
+      const rows = await fetchTenantsFromSheet()
+      setTenants(rows)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to load tenants"
+      setError(message)
+      const mirror = listTenants()
+      setTenants(mirror)
+      if (mirror.length > 0) setUsingMirror(true)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   useEffect(() => {
-    setTenants(listTenants())
+    void load()
   }, [])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return tenants
+    return tenants.filter(
+      (t) => t.tenant_code.toLowerCase().includes(q) || t.tenant_name.toLowerCase().includes(q),
+    )
+  }, [query, tenants])
 
   const toggleStatus = (tenant: Tenant) => {
     const nextStatus: TenantStatus = tenant.status === "Active" ? "Inactive" : "Active"
@@ -22,48 +52,93 @@ export default function AdminTenants() {
 
   return (
     <AppShell title="Tenants" subtitle="Administer tenant records" navSections={adminNav} chips={["Admin", "CoreSight"]}>
-      <div className="cs-card" style={{ padding: 18 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
-          <h3 style={{ margin: 0 }}>All tenants</h3>
-          <Link className="cs-btn cs-btn-primary" to="/admin/tenants/new">
-            + Create Tenant
-          </Link>
+      <div className="cs-card" style={{ padding: 18, display: "grid", gap: 12 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h3 style={{ margin: 0 }}>All tenants</h3>
+            <p style={{ margin: 0, color: "var(--text-secondary)" }}>
+              Source of truth: Google Sheet. {usingMirror ? "Showing mirror copy (may be outdated)." : "Live fetch."}
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <input
+              className="cs-input"
+              placeholder="Search code or name"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              style={{ minWidth: 200 }}
+            />
+            <button className="cs-btn" onClick={load} disabled={loading}>
+              {loading ? "Refreshing…" : "Refresh"}
+            </button>
+            <Link className="cs-btn cs-btn-primary" to="/admin/tenants/new">
+              + Create Tenant
+            </Link>
+          </div>
         </div>
+
+        {error ? (
+          <div
+            style={{
+              border: "1px solid var(--border)",
+              background: "rgba(255,255,255,0.04)",
+              color: "var(--text)",
+              padding: 12,
+              borderRadius: 12,
+            }}
+          >
+            Unable to reach Google Sheet: {error}. {usingMirror ? "Loaded from local mirror." : ""}
+          </div>
+        ) : null}
+
         <div style={{ overflow: "auto" }}>
           <table className="cs-table">
             <thead>
               <tr>
                 <th className="cs-th">Tenant</th>
                 <th className="cs-th">Code</th>
-                <th className="cs-th">Region</th>
+                <th className="cs-th">Country</th>
+                <th className="cs-th">Plan</th>
+                <th className="cs-th">Subscription</th>
                 <th className="cs-th">Status</th>
+                <th className="cs-th">Created</th>
                 <th className="cs-th">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {tenants.map((tenant, idx) => (
+              {filtered.map((tenant, idx) => (
                 <tr key={tenant.tenant_id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
                   <td className="cs-td">
                     <div style={{ fontWeight: 800 }}>{tenant.tenant_name}</div>
-                    <div style={{ color: "var(--muted)", fontSize: 12 }}>{tenant.legal_name}</div>
+                    <div style={{ color: "var(--muted)", fontSize: 12 }}>{tenant.tenant_type || tenant.legal_name}</div>
                   </td>
                   <td className="cs-td">{tenant.tenant_code}</td>
                   <td className="cs-td">{tenant.region ?? "-"}</td>
+                  <td className="cs-td">{tenant.plan_type || tenant.subscription || "-"}</td>
+                  <td className="cs-td">{tenant.subscription_status || "-"}</td>
                   <td className="cs-td">
-                    <span className="cs-pill" style={{ background: "rgba(77,163,255,0.12)", borderColor: "var(--border)" }}>
+                    <span className="cs-pill" style={{ background: "rgba(255,255,255,0.05)", borderColor: "var(--border)" }}>
                       {tenant.status}
                     </span>
                   </td>
-                  <td className="cs-td" style={{ display: "flex", gap: 10 }}>
+                  <td className="cs-td">{tenant.created_at ? tenant.created_at.slice(0, 10) : "-"}</td>
+                  <td className="cs-td" style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
                     <Link className="cs-btn" to={`/admin/tenants/${tenant.tenant_id}/edit`}>
                       View / Edit
                     </Link>
-                    <button className="cs-btn" onClick={() => toggleStatus(tenant)}>
+                    <button className="cs-btn" onClick={() => toggleStatus(tenant)} disabled={loading}>
                       {tenant.status === "Active" ? "Deactivate" : "Activate"}
                     </button>
                   </td>
                 </tr>
               ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td className="cs-td" colSpan={8} style={{ textAlign: "center", color: "var(--muted)" }}>
+                    {loading ? "Loading tenants…" : "No tenants match the filter."}
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>

--- a/src/pages/admin/VendorNew.tsx
+++ b/src/pages/admin/VendorNew.tsx
@@ -9,6 +9,7 @@ import {
   makeTenantId,
 } from "../../data/vendors"
 import { upsertTenantMirrorFromSheet } from "../../data/tenants"
+import { ensureTenantLifecycleRecords } from "../../data/tenantRecords"
 
 const SHEET_URL =
   "https://script.google.com/macros/s/AKfycbwxTAPJITLdR3AUQoseEs-TsUefbWfuPPmt2rrqsmgDBGXSfAL3xDeUG10VLKUrGhDb0w/exec"
@@ -160,7 +161,10 @@ export default function VendorNew() {
         throw new Error(json?.error || "Create failed")
       }
 
-      upsertTenantMirrorFromSheet(payload)
+      const mirrorTenant = upsertTenantMirrorFromSheet(payload)
+      if (mirrorTenant) {
+        ensureTenantLifecycleRecords(mirrorTenant)
+      }
 
       setSuccess("✅ Tenant created and appended to Google Sheet.")
       setStep(1)

--- a/src/pages/customer/Renewals.tsx
+++ b/src/pages/customer/Renewals.tsx
@@ -1,34 +1,24 @@
+import { useEffect, useState } from "react"
+import { ensureTenantLifecycleRecords, listRenewalsByTenant } from "../../data/tenantRecords"
+import { useCustomerAuth } from "../../auth/CustomerAuthContext"
 import CustomerPageShell from "./CustomerPageShell"
 
-const renewals = [
-  {
-    subscription: "Enterprise",
-    date: "2024-11-15",
-    term: "12 months",
-    status: "On track",
-    owner: "Procurement",
-    notes: "Awaiting approval",
-  },
-  {
-    subscription: "AI Insights Add-on",
-    date: "2024-07-20",
-    term: "12 months",
-    status: "Pending",
-    owner: "IT Ops",
-    notes: "Needs usage review",
-  },
-]
-
 export default function CustomerRenewals() {
+  const { tenant } = useCustomerAuth()
+  const [rows, setRows] = useState(() => (tenant ? listRenewalsByTenant(tenant.tenant_id) : []))
+
+  useEffect(() => {
+    if (!tenant) return
+    ensureTenantLifecycleRecords(tenant)
+    setRows(listRenewalsByTenant(tenant.tenant_id))
+  }, [tenant])
+
   return (
-    <CustomerPageShell
-      title="Renewals"
-      subtitle="Key renewal dates and owners"
-    >
+    <CustomerPageShell title="Renewals" subtitle="Key renewal dates and owners">
       <div className="cs-card" style={{ padding: 18, display: "grid", gap: 14 }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <div>
-            <h3 style={{ margin: 0 }}>Upcoming renewals</h3>
+            <h3 style={{ margin: 0 }}>{tenant ? `${tenant.tenant_name} renewals` : "Upcoming renewals"}</h3>
             <p style={{ margin: 0, color: "var(--text-secondary)" }}>
               Track renewal readiness and assign owners.
             </p>
@@ -49,23 +39,30 @@ export default function CustomerRenewals() {
             </tr>
           </thead>
           <tbody>
-            {renewals.map((row, idx) => (
-              <tr key={`${row.subscription}-${row.date}`} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+            {rows.map((row, idx) => (
+              <tr key={row.id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
                 <td className="cs-td">{row.subscription}</td>
-                <td className="cs-td">{row.date}</td>
+                <td className="cs-td">{row.renewal_date}</td>
                 <td className="cs-td">{row.term}</td>
                 <td className="cs-td">
                   <span className="cs-pill" style={{ padding: "6px 10px", background: "var(--surface-elevated)" }}>
                     {row.status}
                   </span>
                 </td>
-                <td className="cs-td">{row.owner}</td>
-                <td className="cs-td">{row.notes}</td>
+                <td className="cs-td">{row.owner || "-"}</td>
+                <td className="cs-td">{row.notes || "-"}</td>
                 <td className="cs-td">
                   <button className="cs-btn" style={{ height: 36 }}>Details</button>
                 </td>
               </tr>
             ))}
+            {rows.length === 0 && (
+              <tr>
+                <td className="cs-td" colSpan={7} style={{ color: "var(--muted)", textAlign: "center" }}>
+                  {tenant ? "No renewals scheduled yet." : "Select a tenant to continue."}
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/pages/customer/Subscriptions.tsx
+++ b/src/pages/customer/Subscriptions.tsx
@@ -1,39 +1,29 @@
+import { useEffect, useState } from "react"
+import { ensureTenantLifecycleRecords, listSubscriptionsByTenant } from "../../data/tenantRecords"
+import { useCustomerAuth } from "../../auth/CustomerAuthContext"
 import CustomerPageShell from "./CustomerPageShell"
 
-const rows = [
-  {
-    plan: "Enterprise",
-    status: "Active",
-    start: "2024-01-01",
-    end: "2024-12-31",
-    seats: 120,
-    renewal: "Annual",
-  },
-  {
-    plan: "AI Insights Add-on",
-    status: "Inactive",
-    start: "2023-08-01",
-    end: "2024-07-31",
-    seats: 30,
-    renewal: "Annual",
-  },
-]
-
 export default function CustomerSubscriptions() {
+  const { tenant } = useCustomerAuth()
+  const [rows, setRows] = useState(() => (tenant ? listSubscriptionsByTenant(tenant.tenant_id) : []))
+
+  useEffect(() => {
+    if (!tenant) return
+    ensureTenantLifecycleRecords(tenant)
+    setRows(listSubscriptionsByTenant(tenant.tenant_id))
+  }, [tenant])
+
   return (
-    <CustomerPageShell
-      title="Subscriptions"
-      subtitle="Current entitlements, terms, and upgrade controls"
-    >
+    <CustomerPageShell title="Subscriptions" subtitle="Current entitlements, terms, and upgrade controls">
       <div className="cs-card" style={{ padding: 18, display: "grid", gap: 14 }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <div>
-            <h3 style={{ margin: 0 }}>Active subscriptions</h3>
+            <h3 style={{ margin: 0 }}>{tenant ? `${tenant.tenant_name} subscriptions` : "Subscriptions"}</h3>
             <p style={{ margin: 0, color: "var(--text-secondary)" }}>
               Boardroom-ready view of your plans and renewal posture.
             </p>
           </div>
-          <button className="cs-btn cs-btn-primary">Request Upgrade</button>
+          <button className="cs-btn cs-btn-primary">Manage Subscription</button>
         </div>
 
         <table className="cs-table">
@@ -50,22 +40,29 @@ export default function CustomerSubscriptions() {
           </thead>
           <tbody>
             {rows.map((row, idx) => (
-              <tr key={row.plan} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+              <tr key={row.id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
                 <td className="cs-td">{row.plan}</td>
                 <td className="cs-td">
                   <span className="cs-pill" style={{ padding: "6px 10px", background: "var(--surface-elevated)" }}>
                     {row.status}
                   </span>
                 </td>
-                <td className="cs-td">{row.start}</td>
-                <td className="cs-td">{row.end}</td>
-                <td className="cs-td">{row.seats}</td>
-                <td className="cs-td">{row.renewal}</td>
+                <td className="cs-td">{row.start_date || "-"}</td>
+                <td className="cs-td">{row.end_date || "-"}</td>
+                <td className="cs-td">{row.seats ?? "-"}</td>
+                <td className="cs-td">{row.renewal_type || "Annual"}</td>
                 <td className="cs-td">
                   <button className="cs-btn" style={{ height: 36 }}>Manage</button>
                 </td>
               </tr>
             ))}
+            {rows.length === 0 && (
+              <tr>
+                <td className="cs-td" colSpan={7} style={{ color: "var(--muted)", textAlign: "center" }}>
+                  {tenant ? "No subscriptions found for this tenant." : "Select a tenant to continue."}
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- add Google Sheet tenant fetch/mirror with admin table filters and calm fallback UI
- enable admin tenant detail to manage primary customer login while seeding subscription/renewal records
- enforce tenant-scoped customer login and surface tenant-specific subscriptions and renewals data

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568139facc832896db5ab3617c308d)