### PR TITLE
Add customer user management and Google Sheet sync actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import CustomerAIInsights from "./pages/customer/AIInsights"
 import CustomerSettings from "./pages/customer/Settings"
 import CustomerSubscriptions from "./pages/customer/Subscriptions"
 import CustomerRenewals from "./pages/customer/Renewals"
+import CustomerUsers from "./pages/customer/Users"
 import AdminLayout from "./layout/AdminLayout"
 import CustomerLayout from "./layout/CustomerLayout"
 import { useAdminAuth } from "./auth/AdminAuthContext"
@@ -38,6 +39,12 @@ function CustomerGuard({ children }: { children: ReactElement }) {
   if (!isAuthenticated && adminAuthed) return <Navigate to="/admin" replace />
   if (!isAuthenticated) return <Navigate to="/customer/login" replace />
   return children
+}
+
+function RequireCustomerPrimary({ children }: { children: ReactElement }) {
+  const { user } = useCustomerAuth()
+  if (user?.role === "CUSTOMER_PRIMARY") return children
+  return <Navigate to="/app/dashboard" replace state={{ message: "You don’t have access to this section." }} />
 }
 
 export default function App() {
@@ -77,13 +84,42 @@ export default function App() {
         >
           <Route index element={<Navigate to="dashboard" replace />} />
           <Route path="dashboard" element={<CustomerDashboard />} />
-          <Route path="subscriptions" element={<CustomerSubscriptions />} />
-          <Route path="renewals" element={<CustomerRenewals />} />
+          <Route
+            path="subscriptions"
+            element={
+              <RequireCustomerPrimary>
+                <CustomerSubscriptions />
+              </RequireCustomerPrimary>
+            }
+          />
+          <Route
+            path="renewals"
+            element={
+              <RequireCustomerPrimary>
+                <CustomerRenewals />
+              </RequireCustomerPrimary>
+            }
+          />
           <Route path="reports" element={<CustomerReports />} />
           <Route path="departments" element={<CustomerDepartments />} />
           <Route path="analytics" element={<CustomerAnalytics />} />
           <Route path="ai-insights" element={<CustomerAIInsights />} />
-          <Route path="settings" element={<CustomerSettings />} />
+          <Route
+            path="settings"
+            element={
+              <RequireCustomerPrimary>
+                <CustomerSettings />
+              </RequireCustomerPrimary>
+            }
+          />
+          <Route
+            path="users"
+            element={
+              <RequireCustomerPrimary>
+                <CustomerUsers />
+              </RequireCustomerPrimary>
+            }
+          />
         </Route>
 
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/pages/customer/CustomerPageShell.tsx
+++ b/src/pages/customer/CustomerPageShell.tsx
@@ -1,15 +1,41 @@
+import { useMemo } from "react"
 import type { ReactNode } from "react"
 import AppShell from "../../layout/AppShell"
 import { customerNav } from "../../navigation/customerNav"
 import { useCustomerAuth } from "../../auth/CustomerAuthContext"
+import type { NavItem } from "../../navigation/types"
 
 export default function CustomerPageShell({ title, subtitle, children }: { title: string; subtitle?: string; children: ReactNode }) {
   const { tenant, user } = useCustomerAuth()
   const chips = [tenant ? tenant.tenant_name : "Tenant", tenant?.region ?? ""]
   const enrichedChips = user ? [...chips, user.email] : chips
 
+  const navItems = useMemo(() => {
+    const usersNav: NavItem = { key: "customer-users", label: "Users", icon: "👥", to: "/app/users" }
+
+    if (user?.role === "CUSTOMER_PRIMARY") {
+      const enriched = [...customerNav]
+      const renewalsIndex = enriched.findIndex((item) => item.key === "customer-renewals")
+      if (renewalsIndex >= 0) {
+        enriched.splice(renewalsIndex + 1, 0, usersNav)
+      } else {
+        enriched.push(usersNav)
+      }
+      return enriched
+    }
+
+    const allowedKeys = new Set([
+      "customer-dashboard",
+      "customer-reports",
+      "customer-departments",
+      "customer-analytics",
+      "customer-ai",
+    ])
+    return customerNav.filter((item) => allowedKeys.has(item.key))
+  }, [user?.role])
+
   return (
-    <AppShell title={title} subtitle={subtitle} navItems={customerNav} chips={enrichedChips.filter(Boolean)}>
+    <AppShell title={title} subtitle={subtitle} navItems={navItems} chips={enrichedChips.filter(Boolean)}>
       {children}
     </AppShell>
   )

--- a/src/pages/customer/Dashboard.tsx
+++ b/src/pages/customer/Dashboard.tsx
@@ -1,6 +1,50 @@
+import { useEffect, useMemo, useState } from "react"
+import type { CSSProperties } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
 import CustomerPageShell from "./CustomerPageShell"
+import { useCustomerAuth } from "../../auth/CustomerAuthContext"
+import {
+  ensureTenantLifecycleRecords,
+  isRenewalExpiringSoon,
+  listRenewalsByTenant,
+  listSubscriptionsByTenant,
+} from "../../data/tenantRecords"
+import type { RenewalRecord, SubscriptionRecord } from "../../data/tenantRecords"
 
 export default function CustomerDashboard() {
+  const { tenant } = useCustomerAuth()
+  const [subscriptions, setSubscriptions] = useState<SubscriptionRecord[]>([])
+  const [renewals, setRenewals] = useState<RenewalRecord[]>([])
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [notice, setNotice] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (location.state && (location.state as { message?: string }).message) {
+      setNotice((location.state as { message?: string }).message)
+      navigate(location.pathname, { replace: true })
+    }
+  }, [location, navigate])
+
+  useEffect(() => {
+    if (!tenant) return
+    ensureTenantLifecycleRecords(tenant)
+    setSubscriptions(listSubscriptionsByTenant(tenant.tenant_id))
+    setRenewals(listRenewalsByTenant(tenant.tenant_id))
+  }, [tenant])
+
+  const nextRenewal = useMemo(() => {
+    const sorted = [...renewals].sort((a, b) => a.renewal_date.localeCompare(b.renewal_date))
+    return sorted[0]
+  }, [renewals])
+
+  const subscriptionStatus = useMemo(() => {
+    const first = subscriptions[0]
+    return first?.subscription_status || first?.status || "—"
+  }, [subscriptions])
+
+  const renewalBadge = nextRenewal && isRenewalExpiringSoon(nextRenewal)
+
   return (
     <CustomerPageShell title="Dashboard" subtitle="Executive overview for your tenant">
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 14 }}>
@@ -10,7 +54,51 @@ export default function CustomerDashboard() {
             <div style={{ color: "var(--text-secondary)" }}>Placeholder KPI card — data wiring comes later.</div>
           </div>
         ))}
+
+        <div className="cs-card" style={{ padding: 16, display: "grid", gap: 6 }}>
+          <div style={{ fontWeight: 800 }}>Subscription Status</div>
+          <div style={{ color: "var(--text-secondary)" }}>Latest subscription posture</div>
+          <div className="cs-pill" style={{ width: "fit-content", padding: "8px 12px", background: "var(--surface)" }}>
+            {subscriptionStatus}
+          </div>
+        </div>
+
+        <div className="cs-card" style={{ padding: 16, display: "grid", gap: 6 }}>
+          <div style={{ fontWeight: 800 }}>Next Renewal</div>
+          <div style={{ color: "var(--text-secondary)" }}>Keep an eye on the next renewal date</div>
+          {nextRenewal ? (
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <div style={{ fontWeight: 800 }}>{nextRenewal.renewal_date}</div>
+              {renewalBadge ? <Badge label="Expiring soon" /> : null}
+            </div>
+          ) : (
+            <div style={{ color: "var(--muted)" }}>No renewals scheduled.</div>
+          )}
+        </div>
       </div>
+
+      {notice ? <div style={{ ...noticeBox }}>{notice}</div> : null}
     </CustomerPageShell>
   )
+}
+
+function Badge({ label }: { label: string }) {
+  return (
+    <span
+      className="cs-pill"
+      style={{ background: "rgba(255,193,7,0.12)", borderColor: "rgba(255,193,7,0.22)", color: "#f1c27d" }}
+    >
+      {label}
+    </span>
+  )
+}
+
+const noticeBox: CSSProperties = {
+  marginTop: 16,
+  padding: 12,
+  borderRadius: 12,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  fontWeight: 700,
+  color: "var(--text)",
 }

--- a/src/pages/customer/Users.tsx
+++ b/src/pages/customer/Users.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from "react"
+import type { CSSProperties } from "react"
+import CustomerPageShell from "./CustomerPageShell"
+import { useCustomerAuth } from "../../auth/CustomerAuthContext"
+import { createUser, listUsersByTenant, resetPassword, updateUser } from "../../data/users"
+import type { User } from "../../data/users"
+
+export default function CustomerUsers() {
+  const { tenant, user } = useCustomerAuth()
+  const [rows, setRows] = useState<User[]>([])
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [notice, setNotice] = useState<string | undefined>()
+  const [error, setError] = useState<string | undefined>()
+
+  useEffect(() => {
+    if (!tenant) return
+    setRows(listUsersByTenant(tenant.tenant_id))
+  }, [tenant])
+
+  const isPrimary = useMemo(() => user?.role === "CUSTOMER_PRIMARY", [user?.role])
+
+  const refresh = () => {
+    if (!tenant) return
+    setRows(listUsersByTenant(tenant.tenant_id))
+  }
+
+  const handleCreate = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!tenant || !isPrimary) return
+    if (!email || !password) {
+      setError("Email and password are required")
+      return
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match")
+      return
+    }
+    createUser({
+      tenant_id: tenant.tenant_id,
+      email: email.trim(),
+      password,
+      role: "CUSTOMER_USER",
+      status: "Active",
+      name: name.trim() || undefined,
+    })
+    setName("")
+    setEmail("")
+    setPassword("")
+    setConfirm("")
+    setError(undefined)
+    setNotice("User created")
+    refresh()
+  }
+
+  const handleResetPassword = (userId: string, targetEmail: string) => {
+    const nextPassword = window.prompt(`Enter new password for ${targetEmail}`)
+    if (!nextPassword) return
+    resetPassword(userId, nextPassword)
+    setNotice("Password reset")
+    refresh()
+  }
+
+  const handleToggleStatus = (userId: string, currentStatus: string) => {
+    const nextStatus = currentStatus === "Active" ? "Inactive" : "Active"
+    updateUser(userId, { status: nextStatus as User["status"] })
+    setNotice(nextStatus === "Active" ? "User activated" : "User deactivated")
+    refresh()
+  }
+
+  if (!tenant) {
+    return (
+      <CustomerPageShell title="Users" subtitle="Manage tenant users">
+        <div className="cs-card" style={{ padding: 18 }}>No tenant selected.</div>
+      </CustomerPageShell>
+    )
+  }
+
+  return (
+    <CustomerPageShell title="Users" subtitle="Manage customer logins for this tenant">
+      <div className="cs-card" style={{ padding: 18, display: "grid", gap: 14 }}>
+        {isPrimary ? (
+          <form
+            onSubmit={handleCreate}
+            style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}
+          >
+            <label style={label}>
+              Name (optional)
+              <input className="cs-input" value={name} onChange={(e) => setName(e.target.value)} />
+            </label>
+            <label style={label}>
+              Email
+              <input className="cs-input" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </label>
+            <label style={label}>
+              Password
+              <input
+                className="cs-input"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </label>
+            <label style={label}>
+              Confirm
+              <input
+                className="cs-input"
+                type="password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+              />
+            </label>
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 10 }}>
+              <button className="cs-btn cs-btn-primary" type="submit">
+                Create user
+              </button>
+              <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>Role: CUSTOMER_USER (default)</div>
+            </div>
+          </form>
+        ) : (
+          <div style={{ color: "var(--text-secondary)" }}>You need primary access to manage users.</div>
+        )}
+
+        {error && <div style={errorBox}>{error}</div>}
+        {notice && <div style={successBox}>{notice}</div>}
+
+        <table className="cs-table">
+          <thead>
+            <tr>
+              <th className="cs-th">Name</th>
+              <th className="cs-th">Email</th>
+              <th className="cs-th">Role</th>
+              <th className="cs-th">Status</th>
+              <th className="cs-th">Created</th>
+              <th className="cs-th">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={row.user_id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
+                <td className="cs-td">{row.name || "—"}</td>
+                <td className="cs-td">{row.email}</td>
+                <td className="cs-td">{row.role}</td>
+                <td className="cs-td">
+                  <span className="cs-pill" style={{ padding: "6px 10px", background: "var(--surface-elevated)" }}>
+                    {row.status}
+                  </span>
+                </td>
+                <td className="cs-td">{row.created_at?.slice(0, 10) || ""}</td>
+                <td className="cs-td" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  <button
+                    className="cs-btn"
+                    style={{ height: 34 }}
+                    onClick={() => handleResetPassword(row.user_id, row.email)}
+                    disabled={!isPrimary}
+                  >
+                    Reset password
+                  </button>
+                  <button
+                    className="cs-btn cs-btn-ghost"
+                    style={{ height: 34 }}
+                    onClick={() => handleToggleStatus(row.user_id, row.status)}
+                    disabled={!isPrimary || row.role === "CUSTOMER_PRIMARY"}
+                  >
+                    {row.status === "Active" ? "Deactivate" : "Activate"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td className="cs-td" colSpan={6} style={{ color: "var(--muted)", textAlign: "center" }}>
+                  No users for this tenant yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </CustomerPageShell>
+  )
+}
+
+const label: CSSProperties = { display: "flex", flexDirection: "column", gap: 6, fontWeight: 700, color: "var(--text-secondary)" }
+
+const errorBox: CSSProperties = {
+  border: "1px solid rgba(255,255,255,0.18)",
+  background: "rgba(255,90,90,0.08)",
+  color: "#ffb4b4",
+  padding: 10,
+  borderRadius: 12,
+  fontWeight: 700,
+}
+
+const successBox: CSSProperties = {
+  border: "1px solid rgba(77,163,255,0.35)",
+  background: "rgba(77,163,255,0.08)",
+  color: "var(--text)",
+  padding: 10,
+  borderRadius: 12,
+  fontWeight: 700,
+}


### PR DESCRIPTION
## Summary
- add a controlled "Sync to Google Sheet" action on the admin tenant edit page using the updateTenant Apps Script payload
- introduce customer user management with primary-only navigation/route access and role fallback logic
- make subscriptions and renewals interactive with status changes, expiring-soon indicators, and dashboard renewal/subscription KPIs

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568bd6775083288619a72c57907dfa)