### PR TITLE
Remove tenant code from UI and align tenant creation

### DIFF
--- a/src/data/vendors.ts
+++ b/src/data/vendors.ts
@@ -12,7 +12,7 @@ export type SubscriptionStatus =
 
 export interface Vendor {
   tenant_id: string
-  tenant_code: string
+  tenant_code?: string
   tenant_name: string
   legal_name?: string
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import AppShell from "../layout/AppShell"
 
 type TenantRow = {
   tenant_id?: string
-  tenant_code?: string
   tenant_name?: string
   tenant_type?: string
   plan_type?: string
@@ -107,7 +106,7 @@ export default function Dashboard() {
             <table style={table}>
               <thead>
                 <tr>
-                  <th style={th}>Code</th>
+                  <th style={th}>Tenant ID</th>
                   <th style={th}>Name</th>
                   <th style={th}>Type</th>
                   <th style={th}>Plan</th>
@@ -118,8 +117,8 @@ export default function Dashboard() {
               </thead>
               <tbody>
                 {recent.map((r, idx) => (
-                  <tr key={`${r.tenant_id || r.tenant_code || idx}`} style={tr}>
-                    <td style={tdMono}>{r.tenant_code || "-"}</td>
+                  <tr key={`${r.tenant_id || idx}`} style={tr}>
+                    <td style={tdMono}>{r.tenant_id || "-"}</td>
                     <td style={td}>{r.tenant_name || "-"}</td>
                     <td style={td}>{r.tenant_type || "-"}</td>
                     <td style={td}>{r.plan_type || "-"}</td>

--- a/src/pages/admin/AdminRequests.tsx
+++ b/src/pages/admin/AdminRequests.tsx
@@ -88,7 +88,7 @@ export default function AdminRequests() {
         <table className="cs-table">
           <thead>
             <tr>
-              <th className="cs-th">Tenant</th>
+              <th className="cs-th">Tenant ID</th>
               <th className="cs-th">Type</th>
               <th className="cs-th">Status</th>
               <th className="cs-th">Requested by</th>
@@ -99,7 +99,7 @@ export default function AdminRequests() {
           <tbody>
             {requests.map((req, idx) => (
               <tr key={req.request_id} style={{ background: idx % 2 === 0 ? "var(--surface)" : "#181c23" }}>
-                <td className="cs-td">{req.tenant_code || req.tenant_id}</td>
+                <td className="cs-td">{req.tenant_id || "–"}</td>
                 <td className="cs-td">{req.type}</td>
                 <td className="cs-td">{req.status}</td>
                 <td className="cs-td">{req.requested_by || "-"}</td>

--- a/src/pages/admin/Vendors.tsx
+++ b/src/pages/admin/Vendors.tsx
@@ -52,7 +52,7 @@ export default function Vendors() {
         <table>
           <thead>
             <tr>
-              <th>Code</th>
+              <th>Tenant ID</th>
               <th>Name</th>
               <th>Type</th>
               <th>Plan</th>
@@ -64,8 +64,8 @@ export default function Vendors() {
           </thead>
           <tbody>
             {rows.map((v) => (
-              <tr key={v.tenant_id}>
-                <td>{v.tenant_code}</td>
+              <tr key={v.tenant_id || v.tenant_code || v.tenant_name}>
+                <td>{v.tenant_id || "-"}</td>
                 <td>{v.tenant_name}</td>
                 <td>{v.tenant_type}</td>
                 <td>{v.plan_type}</td>

--- a/src/pages/customer/Renewals.tsx
+++ b/src/pages/customer/Renewals.tsx
@@ -21,7 +21,6 @@ export default function CustomerRenewals() {
     if (!tenant || !user) return
     createRequest({
       tenant_id: tenant.tenant_id,
-      tenant_code: tenant.tenant_code,
       requested_by: user.email,
       requested_by_user_id: user.user_id,
       type: "RENEWAL_REQUEST",

--- a/src/pages/customer/Settings.tsx
+++ b/src/pages/customer/Settings.tsx
@@ -10,7 +10,7 @@ export default function CustomerSettings() {
         {tenant ? (
           <>
             {infoRow("Tenant", tenant.tenant_name)}
-            {infoRow("Code", tenant.tenant_code)}
+            {infoRow("Tenant ID", tenant.tenant_id)}
             {infoRow("Legal name", tenant.legal_name ?? "–")}
             {infoRow("Region", tenant.region ?? "–")}
             {infoRow("Timezone", tenant.timezone ?? "–")}

--- a/src/pages/customer/Subscriptions.tsx
+++ b/src/pages/customer/Subscriptions.tsx
@@ -21,7 +21,6 @@ export default function CustomerSubscriptions() {
     if (!tenant || !user) return
     createRequest({
       tenant_id: tenant.tenant_id,
-      tenant_code: tenant.tenant_code,
       requested_by: user.email,
       requested_by_user_id: user.user_id,
       type: "UPGRADE_REQUEST",


### PR DESCRIPTION
## Summary
- replace tenant_code displays and request payloads with tenant_id across customer/admin views
- update vendor onboarding to drop tenant_code input, enforce required legal/VAT/address fields, and add currency dropdown
- keep sheet sync compatibility while making tenant_code optional in tenant/vendor data models

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956de7fa5c0832897de4d815ea51a6f)