### PR TITLE
Add UI theme & font preferences, light theme, and sidebar pin control

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,7 @@
   --accent: #4da3ff;
   --accent-hover: #63b4ff;
   --focus-ring: rgba(77, 163, 255, 0.35);
+  --accent-contrast: #041018;
 
   /* Radii */
   --radius-lg: 18px;
@@ -36,13 +37,37 @@
   /* Legacy aliases (for existing components) */
   --bg: var(--background);
 
-  font-family: "Inter", "Segoe UI", system-ui, -apple-system, "SF Pro Display", "SF Pro Text",
+  --font-family: "Inter", "Segoe UI", system-ui, -apple-system, "SF Pro Display", "SF Pro Text",
     "Helvetica Neue", Arial, sans-serif;
+
+  font-family: var(--font-family);
   color: var(--text);
   background: var(--background);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+[data-theme="light"] {
+  --background: #f5f7fb;
+  --surface: #ffffff;
+  --surface-elevated: #f1f4f9;
+  --card: #ffffff;
+
+  --text: #0f172a;
+  --text-secondary: #475569;
+  --muted: #64748b;
+
+  --border: rgba(15, 23, 42, 0.12);
+  --border-soft: rgba(15, 23, 42, 0.08);
+  --shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+  --shadow-sm: 0 12px 26px rgba(15, 23, 42, 0.12);
+  --shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.12);
+
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --focus-ring: rgba(37, 99, 235, 0.28);
+  --accent-contrast: #ffffff;
 }
 
 * { box-sizing: border-box; }
@@ -124,7 +149,7 @@ button, input, select, textarea {
 .cs-btn-primary {
   border: 1px solid transparent;
   background: var(--accent);
-  color: #041018;
+  color: var(--accent-contrast);
   font-weight: 700;
   box-shadow: var(--shadow-sm);
 }

--- a/src/layout/AppShell.tsx
+++ b/src/layout/AppShell.tsx
@@ -9,6 +9,7 @@ import type { NavItem } from "../navigation/types"
 import { customerNav } from "../navigation/customerNav"
 import { adminNav } from "../navigation/adminNav"
 import { useNavItemsContext } from "../navigation/NavItemsProvider"
+import UiControls from "./UiControls"
 
 export type AppShellProps = {
   title: string
@@ -72,6 +73,8 @@ export default function AppShell({
 
           <div style={topRight}>
             {actions ? <div style={actionsWrap}>{actions}</div> : null}
+
+            <UiControls compact />
 
             {(chips ?? defaultChips).map((chipNode, idx) => (
               <span key={idx} style={chip}>

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -29,23 +29,16 @@ export default function Sidebar({ items, onWidthChange }: { items: NavItem[]; on
           <div style={brandName}>CS</div>
           <button
             className="cs-btn cs-btn-ghost"
-            style={toggle}
-            aria-label={expanded ? "Collapse navigation" : "Expand navigation"}
+            style={{ ...toggle, ...(isPinned ? toggleActive : null) }}
+            aria-label={isPinned ? "Unpin sidebar" : "Pin sidebar"}
+            title={isPinned ? "Unpin sidebar" : "Pin sidebar"}
             onClick={() => setIsPinned((v) => {
               const next = !v
               if (!next) setIsHovered(false)
               return next
             })}
           >
-            <span
-              style={{
-                display: "inline-block",
-                transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
-                transition: "transform 200ms ease",
-              }}
-            >
-              ➜
-            </span>
+            <span style={{ fontSize: 14 }}>{isPinned ? "📌" : "📍"}</span>
           </button>
         </div>
         {expanded && <div style={brandSub}>CoreSight — Enterprise control</div>}
@@ -101,7 +94,7 @@ function SideLink({ to, label, icon, collapsed }: NavItem & { collapsed: boolean
 const sidebar: CSSProperties = {
   padding: 14,
   borderRight: "1px solid var(--border)",
-  background: "linear-gradient(180deg, rgba(18,22,30,0.96), rgba(11,14,20,0.94))",
+  background: "var(--surface)",
   backdropFilter: "blur(10px)",
   display: "flex",
   flexDirection: "column",
@@ -119,7 +112,7 @@ const brand: CSSProperties = {
   padding: 12,
   borderRadius: 14,
   border: "1px solid var(--border)",
-  background: "rgba(255,255,255,0.02)",
+  background: "var(--surface-elevated)",
   boxShadow: "var(--shadow-sm)",
   marginBottom: 8,
 }
@@ -142,6 +135,11 @@ const toggle: CSSProperties = {
   background: "var(--surface)",
   color: "var(--text)",
   boxShadow: "none",
+}
+
+const toggleActive: CSSProperties = {
+  borderColor: "var(--accent)",
+  boxShadow: "0 0 0 2px var(--focus-ring)",
 }
 
 const navItem: CSSProperties = {

--- a/src/layout/UiControls.tsx
+++ b/src/layout/UiControls.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react"
+import {
+  applyUiPreferences,
+  getUiPreferences,
+  setUiPreferences,
+  uiFontOptions,
+  type ThemeMode,
+} from "../lib/uiPreferences"
+
+export default function UiControls({ compact = false }: { compact?: boolean }) {
+  const [preferences, setPreferences] = useState(getUiPreferences)
+
+  useEffect(() => {
+    applyUiPreferences(preferences)
+  }, [preferences])
+
+  const updateTheme = (nextTheme: ThemeMode) => {
+    const next = { ...preferences, theme: nextTheme }
+    setPreferences(next)
+    setUiPreferences(next)
+  }
+
+  const updateFont = (nextFont: (typeof uiFontOptions)[number]["value"]) => {
+    const next = { ...preferences, font: nextFont }
+    setPreferences(next)
+    setUiPreferences(next)
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+      <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: compact ? 12 : 13, fontWeight: 700 }}>
+        Font
+        <select
+          className="cs-select"
+          value={preferences.font}
+          onChange={(event) => updateFont(event.target.value as (typeof uiFontOptions)[number]["value"])}
+          style={{ height: compact ? 32 : 38, paddingInline: 8, fontSize: compact ? 12 : 13 }}
+        >
+          {uiFontOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button
+        className="cs-btn"
+        style={{ height: compact ? 32 : 38, paddingInline: 12, fontSize: compact ? 12 : 13 }}
+        onClick={() => updateTheme(preferences.theme === "dark" ? "light" : "dark")}
+      >
+        {preferences.theme === "dark" ? "Light mode" : "Dark mode"}
+      </button>
+    </div>
+  )
+}

--- a/src/lib/uiPreferences.ts
+++ b/src/lib/uiPreferences.ts
@@ -1,0 +1,51 @@
+import { readStorage, writeStorage } from "./storage"
+
+export type ThemeMode = "dark" | "light"
+export type FontChoice = "inter" | "system" | "serif"
+
+export type UiPreferences = {
+  theme: ThemeMode
+  font: FontChoice
+}
+
+const STORAGE_KEY = "coresight_ui_preferences"
+
+const FONT_STACKS: Record<FontChoice, string> = {
+  inter:
+    "Inter, 'Segoe UI', system-ui, -apple-system, 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif",
+  system:
+    "system-ui, -apple-system, 'Segoe UI', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif",
+  serif: "'Iowan Old Style', 'Times New Roman', Times, serif",
+}
+
+const defaultPreferences: UiPreferences = {
+  theme: "dark",
+  font: "inter",
+}
+
+export function getUiPreferences(): UiPreferences {
+  const stored = readStorage<UiPreferences | null>(STORAGE_KEY, null)
+  if (!stored) return defaultPreferences
+  return {
+    theme: stored.theme === "light" ? "light" : "dark",
+    font: stored.font in FONT_STACKS ? stored.font : defaultPreferences.font,
+  }
+}
+
+export function applyUiPreferences(preferences: UiPreferences) {
+  if (typeof document === "undefined") return
+  const root = document.documentElement
+  root.dataset.theme = preferences.theme
+  root.style.setProperty("--font-family", FONT_STACKS[preferences.font])
+}
+
+export function setUiPreferences(preferences: UiPreferences) {
+  writeStorage(STORAGE_KEY, preferences)
+  applyUiPreferences(preferences)
+}
+
+export const uiFontOptions = [
+  { value: "inter" as const, label: "Inter" },
+  { value: "system" as const, label: "System" },
+  { value: "serif" as const, label: "Serif" },
+]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,9 @@ import App from "./App"
 import "./index.css"
 import { AdminAuthProvider } from "./auth/AdminAuthContext"
 import { CustomerAuthProvider } from "./auth/CustomerAuthContext"
+import { applyUiPreferences, getUiPreferences } from "./lib/uiPreferences"
+
+applyUiPreferences(getUiPreferences())
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import type { FormEvent } from "react"
 import { Link, Navigate, useNavigate } from "react-router-dom"
 import { useAdminAuth } from "../auth/AdminAuthContext"
+import UiControls from "../layout/UiControls"
 
 export default function AdminLogin() {
   const { login, isAuthenticated } = useAdminAuth()
@@ -32,6 +33,9 @@ export default function AdminLogin() {
           <Link to="/customer/login" style={{ ...switchLink }}>
             Go to Customer Login
           </Link>
+        </div>
+        <div style={topRow}>
+          <UiControls compact />
         </div>
         <p style={eyebrow}>Admin access</p>
         <h2 style={title}>Administrator login</h2>
@@ -83,6 +87,12 @@ const card: React.CSSProperties = {
   border: "1px solid var(--border)",
   background: "var(--surface-elevated)",
   boxShadow: "var(--shadow-sm)",
+}
+
+const topRow: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  marginBottom: 10,
 }
 
 const eyebrow: React.CSSProperties = { color: "var(--muted)", textTransform: "uppercase", letterSpacing: 3, fontWeight: 800, fontSize: 11 }

--- a/src/pages/CustomerLogin.tsx
+++ b/src/pages/CustomerLogin.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from "react"
 import { Link, Navigate, useNavigate } from "react-router-dom"
 import { useCustomerAuth, seedDemoUsers } from "../auth/CustomerAuthContext"
 import { ensureSeedTenant } from "../data/tenants"
+import UiControls from "../layout/UiControls"
 
 function CustomerLogin() {
   const { isAuthenticated, login } = useCustomerAuth()
@@ -58,6 +59,9 @@ function CustomerLogin() {
           <Link to="/admin/login" style={switchLink}>
             Go to Admin Login
           </Link>
+        </div>
+        <div style={topRow}>
+          <UiControls compact />
         </div>
 
         <p style={eyebrow}>Customer access</p>
@@ -136,6 +140,12 @@ const card: React.CSSProperties = {
   border: "1px solid var(--border)",
   background: "var(--surface-elevated)",
   boxShadow: "var(--shadow-sm)",
+}
+
+const topRow: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  marginBottom: 10,
 }
 
 const eyebrow: React.CSSProperties = {

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,15 +1,19 @@
 import { Link } from "react-router-dom"
+import UiControls from "../layout/UiControls"
 
 export default function Landing() {
   return (
     <div style={container}>
       <div style={heroBox}>
+        <div style={topRow}>
+          <UiControls compact />
+        </div>
         <p style={eyebrow}>CoreSight Prototype</p>
         <h1 style={title}>Choose your entry point</h1>
         <p style={subtitle}>Boardroom-ready access for admins and customers. Dark-first, calm gradients.</p>
 
         <div style={actions}>
-          <Link to="/customer/login" style={{ ...cta, background: "var(--accent)", color: "#041018" }}>
+          <Link to="/customer/login" style={{ ...cta, background: "var(--accent)", color: "var(--accent-contrast)" }}>
             Customer Login
           </Link>
           <Link to="/admin/login" style={{ ...cta, border: "1px solid var(--border)", color: "var(--text)" }}>
@@ -39,8 +43,14 @@ const heroBox: React.CSSProperties = {
   padding: 40,
   borderRadius: 24,
   border: "1px solid var(--border)",
-  background: "linear-gradient(180deg, rgba(22,26,32,0.96), rgba(16,18,23,0.98))",
+  background: "var(--surface-elevated)",
   boxShadow: "var(--shadow)",
+}
+
+const topRow: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  marginBottom: 10,
 }
 
 const eyebrow: React.CSSProperties = {


### PR DESCRIPTION
### Motivation
- Provide a global UI option to change fonts across pages so users can pick a preferred font stack.
- Allow switching between dark and light modes that update the full layout color tokens including button contrast.
- Give the sidebar a pin/unpin control so users can lock it expanded or return it to hover-collapsible behavior.

### Description
- Add a persisted preferences library `src/lib/uiPreferences.ts` exposing `getUiPreferences`, `applyUiPreferences`, `setUiPreferences`, and font options, and apply preferences at app startup in `src/main.tsx`.
- Add a reusable `UiControls` component (`src/layout/UiControls.tsx`) that exposes a font selector and theme toggle and persistently updates preferences.
- Wire `UiControls` into the top bar and login/landing pages by updating `src/layout/AppShell.tsx`, `src/pages/Landing.tsx`, `src/pages/AdminLogin.tsx`, and `src/pages/CustomerLogin.tsx`.
- Update styles in `src/index.css` to use a `--font-family` variable, introduce `[data-theme="light"]` tokens (background, surface, shadows, `--accent-contrast`), and adjust primary button color to use `--accent-contrast`, and adjust sidebar visuals and add a pin style (`src/layout/Sidebar.tsx`).

### Testing
- Started the dev server with `npm run dev` to verify the app loads and the UI changes are available, which succeeded.
- Ran a Playwright script using Firefox to capture a screenshot of the landing page with the new controls, which succeeded and produced an artifact screenshot.
- Attempted a Playwright Chromium run which failed due to a browser launch crash (`SIGSEGV`) during automated Chromium launch, not related to app logic.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963296065d083289adec597517f05e2)