### PR TITLE
Add primary country selector to tenant onboarding admin step

### DIFF
--- a/src/pages/admin/VendorNew.tsx
+++ b/src/pages/admin/VendorNew.tsx
@@ -446,6 +446,20 @@ export default function VendorNew() {
                   />
                 </Field>
 
+                <Field label="Primary Country *">
+                  <select
+                    className="cs-input"
+                    value={primary_country}
+                    onChange={(e) => setCountry(e.target.value)}
+                  >
+                    {countryOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </Field>
+
                 <Field label="Primary Timezone">
                   <input
                     className="cs-input"


### PR DESCRIPTION
### Motivation
- The admin step of the tenant onboarding form previously captured `primary_country` in state but had no UI control to set it. 
- Expose a required primary country field in the form so users can explicitly choose the tenant's country. 
- Reuse the existing canonical country list to ensure consistency across the app. 
- Support existing validation that checks `primary_country.trim()` before advancing.

### Description
- Add a `Primary Country *` `select` Field to the Admin step in `src/pages/admin/VendorNew.tsx` that binds to `primary_country` and `setCountry`.
- Populate the dropdown options from the shared `countryOptions` array so the list is consistent with `src/data/countries.ts`.
- No changes to state shape or server payload; the default state value remains `"Saudi Arabia"`.
- The change is limited to the UI: ~14 lines added in `VendorNew.tsx`.

### Testing
- Started the dev server with `npm run dev` and the Vite dev server reported ready, which succeeded. 
- Ran a Playwright script that navigated to `#/admin/vendor/new` and captured `artifacts/vendor-new-primary-country.png`, which completed successfully. 
- No unit or integration test suites were executed as part of this change. 
- Code changes were compiled and the page rendered without runtime errors during the manual automated smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633ad4e8d083288d44ddfe9fafce3e)