### PR TITLE
Enforce unique 5‑digit numeric tenant IDs and center action buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,9 @@ button, input, select, textarea {
 
 /* Buttons */
 .cs-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   height: 44px;
   padding: 0 14px;
   border-radius: var(--radius-sm);


### PR DESCRIPTION
### Motivation

- Tenant identifiers must be numeric 5‑digit values and must be unique when created or mirrored from sheet data.
- When mirroring tenant rows from legacy Sheets, preserve the original legacy identifier in `tenant_code` while mapping to a valid numeric `tenant_id`.
- Action buttons (e.g. "View / Edit") are visually misaligned and should have centered labels for consistent UI.

### Description

- In `createTenant` added a uniqueness check (`existingIdSet`) so a provided `payload.tenant_id` is only used if `isValidTenantId(preferredId)` and it is not already present, otherwise `generateTenantId(existingIds)` is used.
- In `upsertTenantMirrorFromSheet` resolve incoming sheet id to `resolvedId` which uses the numeric `payload.tenant_id` when valid or generates a new 5‑digit id, and preserve the original legacy id in `tenant_code` when remapping by setting `tenant_code: payload.tenant_code?.trim() || (resolvedId !== id ? id : undefined)`.
- Updated shared button styles in `src/index.css` by making `.cs-btn` `display: inline-flex` with `align-items: center` and `justify-content: center` so button text is vertically and horizontally centered.

### Testing

- Started the dev server with `npm run dev` (Vite) and the server reported ready, which succeeded.
- Ran a Playwright script to open `/admin/tenants` and capture a screenshot verifying button alignment, and the screenshot artifact was produced successfully.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633ce1a8cc83288092479c31ba3760)