### PR TITLE
Fix tenant create navigation and font scaling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -141,6 +141,9 @@ button, input, select, textarea {
   border: 1px solid var(--border);
   background: var(--surface-elevated);
   color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   transition: transform 140ms ease, box-shadow 200ms ease, background 200ms ease, border-color 200ms ease;
 }
@@ -210,7 +213,7 @@ button, input, select, textarea {
 }
 .cs-th {
   text-align: left;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--muted);
   padding: 12px 14px;
   border-bottom: 1px solid var(--border);
@@ -221,7 +224,7 @@ button, input, select, textarea {
 .cs-td {
   padding: 12px 14px;
   border-bottom: 1px solid var(--border);
-  font-size: 14px;
+  font-size: 0.875rem;
   white-space: nowrap;
   color: var(--text);
 }

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -153,7 +153,7 @@ export default function AdminHome() {
                   <Link to="/admin/vendors" style={ghostLink}>
                     View
                   </Link>
-                  <Link to="/admin/vendor-new" style={primaryLink}>
+                  <Link to="/admin/tenants/new" style={primaryLink}>
                     + Create
                   </Link>
                 </div>


### PR DESCRIPTION
### Motivation

- The Platform Admin "Create" button was routing to an incorrect path instead of the tenant creation screen. 
- The button label on the create screen needed centered alignment for consistent visuals. 
- The global font size selector did not affect table text because table font sizes used fixed pixel values. 

### Description

- Update the Tenants card create link in `src/pages/admin/AdminHome.tsx` to point to `"/admin/tenants/new"` instead of the old path. 
- Center button labels by making the shared button class `.cs-btn` use `display: inline-flex` with `align-items` and `justify-content` in `src/index.css`. 
- Make table header and cell sizes responsive to the global font scale by switching `.cs-th` and `.cs-td` to `rem`-based `font-size` values in `src/index.css`. 

### Testing

- Started the dev server with `npm run dev` and the Vite server came up successfully. 
- Navigated to `/#/admin/tenants` and captured a screenshot with Playwright to verify the create button routing and alignment, which completed successfully. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633d657a28832887d0423c7aa88195)